### PR TITLE
Fix null reference timing problem in Chrome

### DIFF
--- a/lib/src/ng2-pdfjs-viewer.component.ts
+++ b/lib/src/ng2-pdfjs-viewer.component.ts
@@ -309,7 +309,7 @@ export class PdfJsViewerComponent implements OnInit, OnDestroy {
     if (this.externalWindow) {
       this.viewerTab.location.href = viewerUrl;
     } else {
-      this.iframe.nativeElement.contentWindow.location.replace(viewerUrl);
+      this.iframe.nativeElement.contentWindow ? this.iframe.nativeElement.contentWindow.location.replace(viewerUrl) : this.iframe.nativeElement.src = viewerUrl;
     }
 
     // console.log(`


### PR DESCRIPTION
A fix done in #44 causes problems reported in #259.

I haven't dug deep into the firefox problem that should have been fixed by the change, but it does cause problems in Chrome and maybe other browsers. 

`document-viewer.component.ts:18 TypeError: Cannot read properties of null (reading 'location')`

Seems to be a timing problem, because setting the src after the component is loaded does not cause the error. As the code worked fine in chrome before the change I made a combination that should fix both problems.