### PR TITLE
fix: relaxed peer dep

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -25,8 +25,8 @@
     "shx": "^0.3.4"
   },
   "peerDependencies": {
-    "@angular/common": "^10.0.0",
-    "@angular/core": "^10.0.0"
+    "@angular/common": ">=10.0.0",
+    "@angular/core": ">=10.0.0"
   },
   "$schema": "./node_modules/ng-packagr/package.schema.json",
   "bugs": {


### PR DESCRIPTION
The relaxation of the peer dependency is nice, but was not correctly implemented. 
It just allowed any @angular/core 10.x.x version. 

I corrected it to allow any version above 10.