### PR TITLE
Harden CI workflows and standardize the license label

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
+# Minimal default token scope; the job below escalates only what it needs.
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,9 +21,9 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           # Angular 22 / ng-packagr 22 / TypeScript 6.0 require Node >= 22.22 / 24.15
           node-version: '24.x'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
 
 name: Create Release
 
+# Minimal default token scope; the job below escalates only what it needs.
+permissions: read-all
+
 jobs:
   release:
     name: Create Release

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,12 +25,12 @@ jobs:
       actions: read
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -38,13 +38,13 @@ jobs:
           publish_results: true
 
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/sync-readme.yml
+++ b/.github/workflows/sync-readme.yml
@@ -1,17 +1,21 @@
 name: Sync README and LICENSE
 on: [push]
+
+# Minimal default token scope; the job below escalates only what it needs.
+permissions: read-all
+
 jobs:
   sync:
     runs-on: ubuntu-latest
     permissions:
       contents: write # git-auto-commit pushes the synced README/LICENSE
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Sync README and LICENSE
         run: |
           cp lib/README.md README.md
           cp lib/LICENSE LICENSE
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5
         with:
           commit_message: "Sync root README and LICENSE with lib/"
           commit_user_name: "GitHub Actions"

--- a/BILL-OF-MATERIALS.md
+++ b/BILL-OF-MATERIALS.md
@@ -6,7 +6,7 @@ A component and license inventory of the **published npm package** `ng2-pdfjs-vi
 | --- | --- |
 | **Package** | `ng2-pdfjs-viewer` |
 | **Version** | 26.0.1 |
-| **License** | Apache-2.0 WITH Commons-Clause |
+| **License** | Apache-2.0 (Commons Clause) |
 | **Runtime npm dependencies** | **none** (zero) |
 | **Peer dependencies** | `@angular/common` `>=10`, `@angular/core` `>=10` |
 | **Distribution** | FESM2022 (ng-packagr) + bundled PDF.js assets under `pdfjs/` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,8 @@
 
 An Angular component library that wraps PDF.js in a single `<ng2-pdfjs-viewer>` component:
 viewing, printing, annotations, zoom, search, theming, and a large declarative input/event
-surface. 8.3M+ downloads. Published to npm as `ng2-pdfjs-viewer`. Open source (Apache-2.0 +
-Commons Clause).
+surface. 8.3M+ downloads. Published to npm as `ng2-pdfjs-viewer`. Open source under
+Apache-2.0 (Commons Clause).
 
 ## Positioning
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![runtime dependencies](https://img.shields.io/badge/runtime%20deps-0-success?style=flat-square)](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/BILL-OF-MATERIALS.md)
 [![PDF.js](https://img.shields.io/badge/PDF.js-6.0.227-green?style=flat-square&logo=mozilla)](https://github.com/mozilla/pdf.js)
 [![Angular](https://img.shields.io/badge/Angular-%3E%3D10-red?style=flat-square&logo=angular)](https://angular.dev)
-[![license](https://img.shields.io/badge/license-Apache--2.0%20%2B%20Commons%20Clause-blue?style=flat-square)](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/LICENSE)
+[![license](https://img.shields.io/badge/license-Apache--2.0%20%28Commons%20Clause%29-blue?style=flat-square)](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/LICENSE)
 [![stars](https://img.shields.io/github/stars/intbot/ng2-pdfjs-viewer?style=flat-square&logo=github)](https://github.com/intbot/ng2-pdfjs-viewer)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/intbot/ng2-pdfjs-viewer/badge)](https://scorecard.dev/viewer/?uri=github.com/intbot/ng2-pdfjs-viewer)
 
@@ -198,7 +198,7 @@ See [CONTRIBUTING.md](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/CON
 
 ## 📄 License
 
-[Apache-2.0 with the Commons Clause](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/LICENSE). Free to use, modify, and self-host; the Commons
+[Apache-2.0 (Commons Clause)](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/LICENSE). Free to use, modify, and self-host; the Commons
 Clause restricts selling the software itself as a hosted/commercial product.
 
 ## 🙏 Acknowledgments

--- a/lib/README.md
+++ b/lib/README.md
@@ -12,7 +12,7 @@
 [![runtime dependencies](https://img.shields.io/badge/runtime%20deps-0-success?style=flat-square)](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/BILL-OF-MATERIALS.md)
 [![PDF.js](https://img.shields.io/badge/PDF.js-6.0.227-green?style=flat-square&logo=mozilla)](https://github.com/mozilla/pdf.js)
 [![Angular](https://img.shields.io/badge/Angular-%3E%3D10-red?style=flat-square&logo=angular)](https://angular.dev)
-[![license](https://img.shields.io/badge/license-Apache--2.0%20%2B%20Commons%20Clause-blue?style=flat-square)](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/LICENSE)
+[![license](https://img.shields.io/badge/license-Apache--2.0%20%28Commons%20Clause%29-blue?style=flat-square)](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/LICENSE)
 [![stars](https://img.shields.io/github/stars/intbot/ng2-pdfjs-viewer?style=flat-square&logo=github)](https://github.com/intbot/ng2-pdfjs-viewer)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/intbot/ng2-pdfjs-viewer/badge)](https://scorecard.dev/viewer/?uri=github.com/intbot/ng2-pdfjs-viewer)
 
@@ -198,7 +198,7 @@ See [CONTRIBUTING.md](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/CON
 
 ## 📄 License
 
-[Apache-2.0 with the Commons Clause](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/LICENSE). Free to use, modify, and self-host; the Commons
+[Apache-2.0 (Commons Clause)](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/LICENSE). Free to use, modify, and self-host; the Commons
 Clause restricts selling the software itself as a hosted/commercial product.
 
 ## 🙏 Acknowledgments

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "ng2-pdfjs-viewer",
       "version": "26.0.1",
-      "license": "Apache-2.0 + Commons Clause",
+      "license": "Apache-2.0 (Commons Clause)",
       "devDependencies": {
         "@angular/compiler-cli": "^22.0.0",
         "esbuild": "^0.28.0",

--- a/lib/package.json
+++ b/lib/package.json
@@ -61,7 +61,7 @@
     "accessibility",
     "open-source"
   ],
-  "license": "Apache-2.0 + Commons Clause",
+  "license": "Apache-2.0 (Commons Clause)",
   "readme": "README.md",
   "scripts": {
     "clean": "shx rm -rf ./dist",


### PR DESCRIPTION
## Summary

Two small, non-functional hardening changes — no library source or runtime dependencies are touched.

### CI hardening
- Pin every GitHub Action to a full commit SHA (with a version comment) instead of a moving major tag.
- Add a top-level `permissions: read-all` scope to each workflow; individual jobs escalate only the scopes they need.

These address the OpenSSF Scorecard **Pinned-Dependencies** and **Token-Permissions** checks. What the workflows do is unchanged.

### License label
- Standardize the human-readable license label to `Apache-2.0 (Commons Clause)` across the README badge and prose, `lib/package.json`, the Bill of Materials, and `CLAUDE.md`. The `LICENSE` legal text is unchanged.