### PR TITLE
Docs landing: theme-aware hero with light/dark toggle

### DIFF
--- a/docs-website/docusaurus.config.ts
+++ b/docs-website/docusaurus.config.ts
@@ -67,6 +67,11 @@ const config: Config = {
   ],
 
   themeConfig: {
+    // Respect the visitor's OS theme; fall back to the dark brand canvas.
+    colorMode: {
+      defaultMode: 'dark',
+      respectPrefersColorScheme: true,
+    },
     // Replace with your project's social card
     image: 'img/ng2-pdfjs-viewer-social-card.png',
     navbar: {

--- a/docs-website/src/components/HomepageFeatures/styles.module.css
+++ b/docs-website/src/components/HomepageFeatures/styles.module.css
@@ -103,3 +103,21 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* ---- Light variant: follow the site color mode so this section stays in
+   step with the hero (no dark block on a light page). ---- */
+:global(html[data-theme='light']) .features {
+  background: #f6f7fb;
+  color: #161a23;
+  border-top-color: rgba(20, 28, 56, 0.08);
+}
+:global(html[data-theme='light']) .kicker { color: #828b9b; }
+:global(html[data-theme='light']) .heading { color: #161a23; }
+:global(html[data-theme='light']) .card {
+  background: linear-gradient(180deg, rgba(20, 28, 56, 0.035), rgba(20, 28, 56, 0.012));
+  border-color: rgba(20, 28, 56, 0.1);
+}
+:global(html[data-theme='light']) .card:hover { border-color: rgba(124, 92, 255, 0.4); }
+:global(html[data-theme='light']) .cardTitle { color: #161a23; }
+:global(html[data-theme='light']) .cardDesc { color: #4a5363; }
+:global(html[data-theme='light']) .cardDesc strong { color: #161a23; }

--- a/docs-website/src/pages/home.module.css
+++ b/docs-website/src/pages/home.module.css
@@ -83,3 +83,40 @@
   .bento { grid-template-columns: 1fr 1fr; }
   .lg { grid-column: span 2; grid-row: span 1; }
 }
+
+/* Hero light/dark toggle (mirrors the Docusaurus color mode). */
+.themeToggle {
+  position: absolute; top: 16px; right: 20px; z-index: 3;
+  width: 38px; height: 38px; border-radius: 10px; cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 16px; line-height: 1; padding: 0;
+  color: var(--ink); background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--border); transition: 0.15s;
+}
+.themeToggle:hover { border-color: rgba(124, 92, 255, 0.5); }
+
+/* ---- Light variant: the landing follows the site color mode so it no longer
+   forces dark; Docusaurus sets data-theme on <html>. ---- */
+:global(html[data-theme='light']) .landing {
+  --ink: #161a23; --muted: #4a5363; --faint: #828b9b;
+  --border: rgba(20, 28, 56, 0.12);
+  background: #f6f7fb;
+}
+:global(html[data-theme='light']) .mesh {
+  background:
+    radial-gradient(50% 40% at 16% 6%, rgba(124, 92, 255, 0.14), transparent 60%),
+    radial-gradient(45% 45% at 88% 10%, rgba(34, 211, 238, 0.12), transparent 60%),
+    radial-gradient(40% 50% at 72% 92%, rgba(255, 138, 92, 0.08), transparent 60%);
+}
+:global(html[data-theme='light']) .eyebrow { background: rgba(20, 28, 56, 0.04); }
+:global(html[data-theme='light']) .btnG,
+:global(html[data-theme='light']) .themeToggle { background: rgba(20, 28, 56, 0.04); }
+:global(html[data-theme='light']) .card3d { background: #ffffff; box-shadow: 0 30px 70px rgba(30, 40, 80, 0.16); }
+:global(html[data-theme='light']) .vt { background: #eef1f7; }
+:global(html[data-theme='light']) .tb { background: #e4e8f0; }
+:global(html[data-theme='light']) .chip { background: #eef1f7; }
+:global(html[data-theme='light']) .vbody { background: linear-gradient(180deg, #eef1f7, #e4e8f1); }
+:global(html[data-theme='light']) .sheet { box-shadow: 0 18px 50px rgba(30, 40, 80, 0.18); }
+:global(html[data-theme='light']) .tile {
+  background: linear-gradient(180deg, rgba(20, 28, 56, 0.035), rgba(20, 28, 56, 0.012));
+}

--- a/docs-website/src/pages/index.tsx
+++ b/docs-website/src/pages/index.tsx
@@ -2,6 +2,7 @@ import Link from '@docusaurus/Link';
 import Head from '@docusaurus/Head';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
+import { useColorMode } from '@docusaurus/theme-common';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
 
 import styles from './home.module.css';
@@ -11,10 +12,19 @@ const PLAYGROUND = 'https://angular-pdf-viewer-demo.vercel.app/';
 const feat = (route: string) => `${PLAYGROUND}#/${route}`;
 
 function Hero() {
+  const { colorMode, setColorMode } = useColorMode();
   return (
     <section className={styles.landing}>
       <div className={styles.mesh} />
       <div className={styles.inner}>
+        <button
+          type="button"
+          className={styles.themeToggle}
+          onClick={() => setColorMode(colorMode === 'dark' ? 'light' : 'dark')}
+          aria-label={`Switch to ${colorMode === 'dark' ? 'light' : 'dark'} theme`}
+        >
+          {colorMode === 'dark' ? '☀' : '☾'}
+        </button>
         <div className={styles.hero}>
           <div>
             <span className={styles.eyebrow}>


### PR DESCRIPTION
## Summary

The docs landing hero was hard-coded dark. This makes it theme-aware:

- The hero and the "Why teams choose it" section now follow the site color mode, with a light variant provided for both — no more dark hero sitting on an otherwise light page.
- A sun/moon toggle on the hero drives the global Docusaurus color mode, staying in sync with the navbar toggle.
- `colorMode` now respects the visitor's OS preference, falling back to the dark brand canvas when there is none.

Docs-only — no library source or dependencies are touched. Verified by building the site and screenshotting both modes.