### PR TITLE
Playground: respect OS theme on first load; viewers follow theme

### DIFF
--- a/playground/src/app/core/services/theme.service.ts
+++ b/playground/src/app/core/services/theme.service.ts
@@ -7,17 +7,38 @@ export class ThemeService {
   readonly mode = signal<Mode>('dark');
 
   constructor() {
-    const saved = (typeof localStorage !== 'undefined' && localStorage.getItem('pg-theme')) as Mode | null;
-    if (saved === 'light' || saved === 'dark') this.set(saved);
+    // saved choice wins; otherwise follow the OS preference; otherwise dark.
+    // An OS-derived default is applied but NOT persisted, so the playground keeps
+    // tracking the OS until the user explicitly toggles.
+    const initial = this.resolveInitial();
+    this.mode.set(initial);
+    this.apply(initial);
   }
 
   set(mode: Mode): void {
     this.mode.set(mode);
-    document.documentElement.setAttribute('data-theme', mode);
+    this.apply(mode);
     try { localStorage.setItem('pg-theme', mode); } catch { /* ignore */ }
   }
 
   toggle(): void {
     this.set(this.mode() === 'dark' ? 'light' : 'dark');
+  }
+
+  private resolveInitial(): Mode {
+    try {
+      const saved = typeof localStorage !== 'undefined' ? localStorage.getItem('pg-theme') : null;
+      if (saved === 'light' || saved === 'dark') return saved;
+      if (typeof window !== 'undefined' && window.matchMedia?.('(prefers-color-scheme: light)').matches) {
+        return 'light';
+      }
+    } catch { /* ignore */ }
+    return 'dark';
+  }
+
+  private apply(mode: Mode): void {
+    if (typeof document !== 'undefined') {
+      document.documentElement.setAttribute('data-theme', mode);
+    }
   }
 }

--- a/playground/src/app/pages/ai/ai.component.html
+++ b/playground/src/app/pages/ai/ai.component.html
@@ -6,7 +6,7 @@
   docHref="https://github.com/intbot/ng2-pdfjs-viewer#readme">
 
   <div preview>
-    <ng2-pdfjs-viewer #viewer [pdfSrc]="src()"
+    <ng2-pdfjs-viewer #viewer [pdfSrc]="src()" [theme]="theme.mode()"
       (onDocumentLoad)="docReady.set(true)"
       (onReadAloudStateChange)="onReadAloud($event)">
     </ng2-pdfjs-viewer>

--- a/playground/src/app/pages/ai/ai.component.ts
+++ b/playground/src/app/pages/ai/ai.component.ts
@@ -1,6 +1,7 @@
 import { Component, computed, effect, inject, signal } from '@angular/core';
 import { PdfJsViewerComponent, PdfJsViewerModule, PdfAiAssistant, ReadAloudState } from 'ng2-pdfjs-viewer';
 import { SamplePdfService } from '../../core/services/sample-pdf.service';
+import { ThemeService } from '../../core/services/theme.service';
 import { PlaygroundLayoutComponent } from '../../shared/playground-layout.component';
 
 @Component({
@@ -19,6 +20,7 @@ import { PlaygroundLayoutComponent } from '../../shared/playground-layout.compon
 })
 export class AiComponent {
   private readonly samples = inject(SamplePdfService);
+  readonly theme = inject(ThemeService);
   readonly src = computed(() => this.samples.current().src);
 
   // BYO endpoint — nothing is called until the user clicks. Defaults target a

--- a/playground/src/app/pages/api/api.component.html
+++ b/playground/src/app/pages/api/api.component.html
@@ -8,6 +8,7 @@
   <div preview>
     <ng2-pdfjs-viewer #viewer
       [pdfSrc]="src()"
+      [theme]="theme.mode()"
       [page]="page()"
       (onPageChange)="onPage($event)"
       (onScaleChange)="onScale($event)"

--- a/playground/src/app/pages/api/api.component.ts
+++ b/playground/src/app/pages/api/api.component.ts
@@ -2,6 +2,7 @@ import { Component, computed, inject, signal } from '@angular/core';
 import { PdfJsViewerComponent, PdfJsViewerModule } from 'ng2-pdfjs-viewer';
 import { CodeGenService } from '../../core/services/code-gen.service';
 import { SamplePdfService } from '../../core/services/sample-pdf.service';
+import { ThemeService } from '../../core/services/theme.service';
 import { PlaygroundLayoutComponent } from '../../shared/playground-layout.component';
 
 @Component({
@@ -14,6 +15,7 @@ import { PlaygroundLayoutComponent } from '../../shared/playground-layout.compon
 export class ApiComponent {
   private readonly codegen = inject(CodeGenService);
   private readonly samples = inject(SamplePdfService);
+  readonly theme = inject(ThemeService);
   readonly src = computed(() => this.samples.current().src);
 
   readonly page = signal(1);

--- a/playground/src/app/pages/auto-actions/auto-actions.component.html
+++ b/playground/src/app/pages/auto-actions/auto-actions.component.html
@@ -11,6 +11,7 @@
     @for (k of [runKey()]; track k) {
       <ng2-pdfjs-viewer
         [pdfSrc]="src()"
+        [theme]="theme.mode()"
         [downloadFileName]="downloadFileName()"
         [downloadOnLoad]="downloadOnLoad()"
         [printOnLoad]="printOnLoad()"

--- a/playground/src/app/pages/auto-actions/auto-actions.component.ts
+++ b/playground/src/app/pages/auto-actions/auto-actions.component.ts
@@ -3,6 +3,7 @@ import { PdfJsViewerModule } from 'ng2-pdfjs-viewer';
 import { CodeBinding } from '../../core/models';
 import { CodeGenService } from '../../core/services/code-gen.service';
 import { SamplePdfService } from '../../core/services/sample-pdf.service';
+import { ThemeService } from '../../core/services/theme.service';
 import { PlaygroundLayoutComponent } from '../../shared/playground-layout.component';
 
 @Component({
@@ -15,6 +16,7 @@ import { PlaygroundLayoutComponent } from '../../shared/playground-layout.compon
 export class AutoActionsComponent {
   private readonly codegen = inject(CodeGenService);
   private readonly samples = inject(SamplePdfService);
+  readonly theme = inject(ThemeService);
   readonly src = computed(() => this.samples.current().src);
 
   readonly downloadOnLoad = signal(false);

--- a/playground/src/app/pages/config-objects/config-objects.component.html
+++ b/playground/src/app/pages/config-objects/config-objects.component.html
@@ -11,6 +11,7 @@
     @for (k of [runKey()]; track k) {
       <ng2-pdfjs-viewer
         [pdfSrc]="src()"
+        [theme]="themeService.mode()"
         [controlVisibility]="controlVisibility()"
         [themeConfig]="themeConfig()"
         [autoActions]="autoActions()"

--- a/playground/src/app/pages/config-objects/config-objects.component.ts
+++ b/playground/src/app/pages/config-objects/config-objects.component.ts
@@ -2,6 +2,7 @@ import { Component, computed, inject, signal } from '@angular/core';
 import { PdfJsViewerModule } from 'ng2-pdfjs-viewer';
 import { CodeGenService } from '../../core/services/code-gen.service';
 import { SamplePdfService } from '../../core/services/sample-pdf.service';
+import { ThemeService } from '../../core/services/theme.service';
 import { PlaygroundLayoutComponent } from '../../shared/playground-layout.component';
 
 @Component({
@@ -14,6 +15,9 @@ import { PlaygroundLayoutComponent } from '../../shared/playground-layout.compon
 export class ConfigObjectsComponent {
   private readonly codegen = inject(CodeGenService);
   private readonly samples = inject(SamplePdfService);
+  // This page already owns a `theme` signal for its themeConfig demo, so the
+  // playground's theme service is injected under a distinct name.
+  readonly themeService = inject(ThemeService);
   readonly src = computed(() => this.samples.current().src);
 
   // controlVisibility

--- a/playground/src/app/pages/custom-ui/custom-ui.component.html
+++ b/playground/src/app/pages/custom-ui/custom-ui.component.html
@@ -23,6 +23,7 @@
 
     <ng2-pdfjs-viewer
       [pdfSrc]="src()"
+      [theme]="theme.mode()"
       [customToolbarTpl]="useCustomToolbar() ? hostToolbar : undefined"
       [showToolbar]="!useCustomToolbar()"
       [pageOverlayTpl]="useOverlays() ? pageBadge : undefined"

--- a/playground/src/app/pages/custom-ui/custom-ui.component.ts
+++ b/playground/src/app/pages/custom-ui/custom-ui.component.ts
@@ -1,6 +1,7 @@
 import { Component, computed, inject, signal } from '@angular/core';
 import { PdfJsViewerModule } from 'ng2-pdfjs-viewer';
 import { SamplePdfService } from '../../core/services/sample-pdf.service';
+import { ThemeService } from '../../core/services/theme.service';
 import { PlaygroundLayoutComponent } from '../../shared/playground-layout.component';
 
 @Component({
@@ -30,6 +31,7 @@ import { PlaygroundLayoutComponent } from '../../shared/playground-layout.compon
 })
 export class CustomUiComponent {
   private readonly samples = inject(SamplePdfService);
+  readonly theme = inject(ThemeService);
   readonly src = computed(() => this.samples.current().src);
 
   readonly useCustomToolbar = signal(true);

--- a/playground/src/app/pages/editor/editor.component.html
+++ b/playground/src/app/pages/editor/editor.component.html
@@ -8,6 +8,7 @@
   <div preview>
     <ng2-pdfjs-viewer #viewer
       [pdfSrc]="src()"
+      [theme]="theme.mode()"
       [annotationEditor]="mode()" (annotationEditorChange)="mode.set($event)"
       [enableSignatureEditor]="signatures()"
       [enableCommentEditor]="comments()"

--- a/playground/src/app/pages/editor/editor.component.ts
+++ b/playground/src/app/pages/editor/editor.component.ts
@@ -1,6 +1,7 @@
 import { Component, computed, inject, signal } from '@angular/core';
 import { PdfJsViewerComponent, PdfJsViewerModule, AnnotationEditorMode, AnnotationEditorState } from 'ng2-pdfjs-viewer';
 import { SamplePdfService } from '../../core/services/sample-pdf.service';
+import { ThemeService } from '../../core/services/theme.service';
 import { PlaygroundLayoutComponent } from '../../shared/playground-layout.component';
 
 @Component({
@@ -20,6 +21,7 @@ import { PlaygroundLayoutComponent } from '../../shared/playground-layout.compon
 })
 export class EditorComponent {
   private readonly samples = inject(SamplePdfService);
+  readonly theme = inject(ThemeService);
   readonly src = computed(() => this.samples.current().src);
 
   readonly mode = signal<AnnotationEditorMode>('none');

--- a/playground/src/app/pages/errors/errors.component.html
+++ b/playground/src/app/pages/errors/errors.component.html
@@ -11,6 +11,7 @@
     @for (v of [urlValidation()]; track v) {
       <ng2-pdfjs-viewer
         [pdfSrc]="src()"
+        [theme]="theme.mode()"
         [errorOverride]="errorOverride()"
         [errorAppend]="errorAppend()"
         [errorMessage]="errorMessage()"

--- a/playground/src/app/pages/errors/errors.component.ts
+++ b/playground/src/app/pages/errors/errors.component.ts
@@ -3,6 +3,7 @@ import { PdfJsViewerModule } from 'ng2-pdfjs-viewer';
 import { CodeBinding } from '../../core/models';
 import { CodeGenService } from '../../core/services/code-gen.service';
 import { SamplePdfService } from '../../core/services/sample-pdf.service';
+import { ThemeService } from '../../core/services/theme.service';
 import { PlaygroundLayoutComponent } from '../../shared/playground-layout.component';
 
 type ErrTpl = 'none' | 'branded' | 'minimal';
@@ -19,6 +20,7 @@ type ErrTpl = 'none' | 'branded' | 'minimal';
 export class ErrorsComponent {
   private readonly codegen = inject(CodeGenService);
   private readonly samples = inject(SamplePdfService);
+  readonly theme = inject(ThemeService);
 
   readonly broken = signal(false);
   readonly protectedDoc = signal(false);

--- a/playground/src/app/pages/events/events.component.html
+++ b/playground/src/app/pages/events/events.component.html
@@ -8,6 +8,7 @@
   <div preview>
     <ng2-pdfjs-viewer
       [pdfSrc]="src()"
+      [theme]="theme.mode()"
       (onDocumentInit)="push('onDocumentInit')"
       (onDocumentLoad)="push('onDocumentLoad')"
       (onPagesInit)="push('onPagesInit', $event)"

--- a/playground/src/app/pages/events/events.component.ts
+++ b/playground/src/app/pages/events/events.component.ts
@@ -2,6 +2,7 @@ import { Component, computed, inject, signal } from '@angular/core';
 import { PdfJsViewerModule } from 'ng2-pdfjs-viewer';
 import { CodeGenService } from '../../core/services/code-gen.service';
 import { SamplePdfService } from '../../core/services/sample-pdf.service';
+import { ThemeService } from '../../core/services/theme.service';
 import { PlaygroundLayoutComponent } from '../../shared/playground-layout.component';
 
 interface LogEntry { t: string; name: string; detail: string; }
@@ -16,6 +17,7 @@ interface LogEntry { t: string; name: string; detail: string; }
 export class EventsComponent {
   private readonly codegen = inject(CodeGenService);
   private readonly samples = inject(SamplePdfService);
+  readonly theme = inject(ThemeService);
   readonly src = computed(() => this.samples.current().src);
 
   readonly log = signal<LogEntry[]>([]);

--- a/playground/src/app/pages/forms/forms.component.html
+++ b/playground/src/app/pages/forms/forms.component.html
@@ -8,6 +8,7 @@
   <div preview>
     <ng2-pdfjs-viewer #viewer
       [pdfSrc]="src"
+      [theme]="theme.mode()"
       [formData]="formData()" (formDataChange)="onFormDataChange($event)">
     </ng2-pdfjs-viewer>
   </div>

--- a/playground/src/app/pages/forms/forms.component.ts
+++ b/playground/src/app/pages/forms/forms.component.ts
@@ -1,5 +1,6 @@
-import { Component, signal } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { PdfJsViewerComponent, PdfJsViewerModule, FormDataMap } from 'ng2-pdfjs-viewer';
+import { ThemeService } from '../../core/services/theme.service';
 import { PlaygroundLayoutComponent } from '../../shared/playground-layout.component';
 
 @Component({
@@ -15,6 +16,7 @@ import { PlaygroundLayoutComponent } from '../../shared/playground-layout.compon
   `],
 })
 export class FormsComponent {
+  readonly theme = inject(ThemeService);
   // This page pins a real AcroForm document (US tax form from the PDF.js
   // test corpus) instead of the global sample picker.
   readonly src = '/assets/samples/form-sample.pdf';

--- a/playground/src/app/pages/loading/loading.component.html
+++ b/playground/src/app/pages/loading/loading.component.html
@@ -9,6 +9,7 @@
     @for (k of [runKey()]; track k) {
       <ng2-pdfjs-viewer
         [pdfSrc]="src()"
+        [theme]="theme.mode()"
         [showSpinner]="showSpinner()"
         [spinnerClass]="spinnerClass() || undefined"
         [customSpinnerTpl]="selectedTpl()">

--- a/playground/src/app/pages/loading/loading.component.ts
+++ b/playground/src/app/pages/loading/loading.component.ts
@@ -3,6 +3,7 @@ import { PdfJsViewerModule } from 'ng2-pdfjs-viewer';
 import { CodeBinding } from '../../core/models';
 import { CodeGenService } from '../../core/services/code-gen.service';
 import { SamplePdfService } from '../../core/services/sample-pdf.service';
+import { ThemeService } from '../../core/services/theme.service';
 import { PlaygroundLayoutComponent } from '../../shared/playground-layout.component';
 
 type TplKind = 'none' | 'dots' | 'bar' | 'pulse';
@@ -18,6 +19,7 @@ type TplKind = 'none' | 'dots' | 'bar' | 'pulse';
 export class LoadingComponent {
   private readonly codegen = inject(CodeGenService);
   private readonly samples = inject(SamplePdfService);
+  readonly theme = inject(ThemeService);
   readonly src = computed(() => this.samples.current().src);
 
   readonly showSpinner = signal(true);

--- a/playground/src/app/pages/localization/localization.component.html
+++ b/playground/src/app/pages/localization/localization.component.html
@@ -9,7 +9,7 @@
     <!-- locale is applied before PDF.js initializes, so a locale change
          needs a fresh viewer — the keyed @for re-creates it. -->
     @for (l of [locale()]; track l) {
-      <ng2-pdfjs-viewer [pdfSrc]="src()" [locale]="l" viewerId="localization"></ng2-pdfjs-viewer>
+      <ng2-pdfjs-viewer [pdfSrc]="src()" [locale]="l" viewerId="localization" [theme]="theme.mode()"></ng2-pdfjs-viewer>
     }
   </div>
 

--- a/playground/src/app/pages/localization/localization.component.ts
+++ b/playground/src/app/pages/localization/localization.component.ts
@@ -2,6 +2,7 @@ import { Component, computed, inject, signal } from '@angular/core';
 import { PdfJsViewerModule } from 'ng2-pdfjs-viewer';
 import { CodeGenService } from '../../core/services/code-gen.service';
 import { SamplePdfService } from '../../core/services/sample-pdf.service';
+import { ThemeService } from '../../core/services/theme.service';
 import { PlaygroundLayoutComponent } from '../../shared/playground-layout.component';
 
 @Component({
@@ -13,6 +14,7 @@ import { PlaygroundLayoutComponent } from '../../shared/playground-layout.compon
 export class LocalizationComponent {
   private readonly codegen = inject(CodeGenService);
   private readonly samples = inject(SamplePdfService);
+  readonly theme = inject(ThemeService);
   readonly src = computed(() => this.samples.current().src);
 
   readonly locale = signal('en-US');

--- a/playground/src/app/pages/navigation/navigation.component.html
+++ b/playground/src/app/pages/navigation/navigation.component.html
@@ -8,6 +8,7 @@
   <div preview>
     <ng2-pdfjs-viewer
       [pdfSrc]="src()"
+      [theme]="theme.mode()"
       [page]="page()"
       [zoom]="zoom()" (zoomChange)="zoom.set($event)"
       [cursor]="cursor()" (cursorChange)="cursor.set($event)"

--- a/playground/src/app/pages/navigation/navigation.component.ts
+++ b/playground/src/app/pages/navigation/navigation.component.ts
@@ -3,6 +3,7 @@ import { PdfJsViewerModule } from 'ng2-pdfjs-viewer';
 import { CodeBinding } from '../../core/models';
 import { CodeGenService } from '../../core/services/code-gen.service';
 import { SamplePdfService } from '../../core/services/sample-pdf.service';
+import { ThemeService } from '../../core/services/theme.service';
 import { PlaygroundLayoutComponent } from '../../shared/playground-layout.component';
 
 @Component({
@@ -15,6 +16,7 @@ import { PlaygroundLayoutComponent } from '../../shared/playground-layout.compon
 export class NavigationComponent {
   private readonly codegen = inject(CodeGenService);
   private readonly samples = inject(SamplePdfService);
+  readonly theme = inject(ThemeService);
   readonly src = computed(() => this.samples.current().src);
 
   readonly zoom = signal('auto');

--- a/playground/src/app/pages/overview/overview.component.html
+++ b/playground/src/app/pages/overview/overview.component.html
@@ -13,7 +13,7 @@
       </div>
     </div>
     <div class="demo">
-      <ng2-pdfjs-viewer [pdfSrc]="src()" viewerId="overview" [showOpenFile]="false"></ng2-pdfjs-viewer>
+      <ng2-pdfjs-viewer [pdfSrc]="src()" viewerId="overview" [showOpenFile]="false" [theme]="theme.mode()"></ng2-pdfjs-viewer>
     </div>
   </section>
 

--- a/playground/src/app/pages/overview/overview.component.ts
+++ b/playground/src/app/pages/overview/overview.component.ts
@@ -5,6 +5,7 @@ import { FEATURES } from '../../core/feature-registry';
 import { FEATURE_GROUPS, FeatureGroup } from '../../core/models';
 import { CommandPaletteService } from '../../core/services/command-palette.service';
 import { SamplePdfService } from '../../core/services/sample-pdf.service';
+import { ThemeService } from '../../core/services/theme.service';
 
 @Component({
   selector: 'pg-overview',
@@ -16,6 +17,7 @@ import { SamplePdfService } from '../../core/services/sample-pdf.service';
 export class OverviewComponent {
   private readonly samples = inject(SamplePdfService);
   readonly palette = inject(CommandPaletteService);
+  readonly theme = inject(ThemeService);
   readonly src = computed(() => this.samples.current().src);
   readonly groups = FEATURE_GROUPS;
 

--- a/playground/src/app/pages/power/power.component.html
+++ b/playground/src/app/pages/power/power.component.html
@@ -8,6 +8,7 @@
   <div preview>
     <ng2-pdfjs-viewer
       [pdfSrc]="src()"
+      [theme]="theme.mode()"
       [enablePageEditing]="pageEditing()"
       [pageColors]="pageColors()"
       [rememberLastView]="rememberLastView()"

--- a/playground/src/app/pages/power/power.component.ts
+++ b/playground/src/app/pages/power/power.component.ts
@@ -1,6 +1,7 @@
 import { Component, computed, inject, signal } from '@angular/core';
 import { PdfJsViewerModule, ExternalLinkTarget, PagesEditedEvent } from 'ng2-pdfjs-viewer';
 import { SamplePdfService } from '../../core/services/sample-pdf.service';
+import { ThemeService } from '../../core/services/theme.service';
 import { PlaygroundLayoutComponent } from '../../shared/playground-layout.component';
 
 @Component({
@@ -12,6 +13,7 @@ import { PlaygroundLayoutComponent } from '../../shared/playground-layout.compon
 })
 export class PowerComponent {
   private readonly samples = inject(SamplePdfService);
+  readonly theme = inject(ThemeService);
   readonly src = computed(() => this.samples.current().src);
 
   readonly pageEditing = signal(false);

--- a/playground/src/app/pages/protection/protection.component.html
+++ b/playground/src/app/pages/protection/protection.component.html
@@ -6,7 +6,7 @@
   docHref="https://github.com/intbot/ng2-pdfjs-viewer#readme">
 
   <div preview>
-    <ng2-pdfjs-viewer [pdfSrc]="src()" [contentProtection]="protection()"></ng2-pdfjs-viewer>
+    <ng2-pdfjs-viewer [pdfSrc]="src()" [contentProtection]="protection()" [theme]="theme.mode()"></ng2-pdfjs-viewer>
   </div>
 
   <div controls>

--- a/playground/src/app/pages/protection/protection.component.ts
+++ b/playground/src/app/pages/protection/protection.component.ts
@@ -1,6 +1,7 @@
 import { Component, computed, inject, signal } from '@angular/core';
 import { PdfJsViewerModule, ContentProtectionConfig } from 'ng2-pdfjs-viewer';
 import { SamplePdfService } from '../../core/services/sample-pdf.service';
+import { ThemeService } from '../../core/services/theme.service';
 import { PlaygroundLayoutComponent } from '../../shared/playground-layout.component';
 
 @Component({
@@ -12,6 +13,7 @@ import { PlaygroundLayoutComponent } from '../../shared/playground-layout.compon
 })
 export class ProtectionComponent {
   private readonly samples = inject(SamplePdfService);
+  readonly theme = inject(ThemeService);
   readonly src = computed(() => this.samples.current().src);
 
   readonly blockPrint = signal(false);

--- a/playground/src/app/pages/quickstart/quickstart.component.html
+++ b/playground/src/app/pages/quickstart/quickstart.component.html
@@ -6,7 +6,7 @@
   docHref="https://github.com/intbot/ng2-pdfjs-viewer#installation">
 
   <div preview>
-    <ng2-pdfjs-viewer [pdfSrc]="src()" viewerId="quickstart"></ng2-pdfjs-viewer>
+    <ng2-pdfjs-viewer [pdfSrc]="src()" viewerId="quickstart" [theme]="theme.mode()"></ng2-pdfjs-viewer>
   </div>
 
   <div controls>

--- a/playground/src/app/pages/quickstart/quickstart.component.ts
+++ b/playground/src/app/pages/quickstart/quickstart.component.ts
@@ -2,6 +2,7 @@ import { Component, computed, inject } from '@angular/core';
 import { PdfJsViewerModule } from 'ng2-pdfjs-viewer';
 import { CodeGenService } from '../../core/services/code-gen.service';
 import { SamplePdfService } from '../../core/services/sample-pdf.service';
+import { ThemeService } from '../../core/services/theme.service';
 import { PlaygroundLayoutComponent } from '../../shared/playground-layout.component';
 
 @Component({
@@ -18,6 +19,7 @@ import { PlaygroundLayoutComponent } from '../../shared/playground-layout.compon
 export class QuickStartComponent {
   private readonly codegen = inject(CodeGenService);
   private readonly samples = inject(SamplePdfService);
+  readonly theme = inject(ThemeService);
   readonly src = computed(() => this.samples.current().src);
 
   readonly code = computed(() =>

--- a/playground/src/app/pages/search/search.component.html
+++ b/playground/src/app/pages/search/search.component.html
@@ -6,7 +6,7 @@
   docHref="https://github.com/intbot/ng2-pdfjs-viewer#readme">
 
   <div preview>
-    <ng2-pdfjs-viewer #viewer [pdfSrc]="src()"></ng2-pdfjs-viewer>
+    <ng2-pdfjs-viewer #viewer [pdfSrc]="src()" [theme]="theme.mode()"></ng2-pdfjs-viewer>
   </div>
 
   <div controls>

--- a/playground/src/app/pages/search/search.component.ts
+++ b/playground/src/app/pages/search/search.component.ts
@@ -1,6 +1,7 @@
 import { Component, computed, inject, signal } from '@angular/core';
 import { PdfJsViewerComponent, PdfJsViewerModule, SearchResult } from 'ng2-pdfjs-viewer';
 import { SamplePdfService } from '../../core/services/sample-pdf.service';
+import { ThemeService } from '../../core/services/theme.service';
 import { PlaygroundLayoutComponent } from '../../shared/playground-layout.component';
 
 @Component({
@@ -17,6 +18,7 @@ import { PlaygroundLayoutComponent } from '../../shared/playground-layout.compon
 })
 export class SearchComponent {
   private readonly samples = inject(SamplePdfService);
+  readonly theme = inject(ThemeService);
   readonly src = computed(() => this.samples.current().src);
 
   readonly query = signal('the');

--- a/playground/src/app/pages/sources/sources.component.html
+++ b/playground/src/app/pages/sources/sources.component.html
@@ -7,10 +7,10 @@
 
   <div preview>
     <!-- urlValidation off: this page legitimately swaps pdfSrc between URL / Blob / bytes -->
-    <ng2-pdfjs-viewer [pdfSrc]="src()" viewerId="sources" [urlValidation]="false"></ng2-pdfjs-viewer>
+    <ng2-pdfjs-viewer [pdfSrc]="src()" viewerId="sources" [urlValidation]="false" [theme]="theme.mode()"></ng2-pdfjs-viewer>
     <!-- renders nothing inline: externalWindow viewers open in their own tab on refresh() -->
     <ng2-pdfjs-viewer #ext class="pg-external" [externalWindow]="true" viewerId="sources-external"
-                      [urlValidation]="false"></ng2-pdfjs-viewer>
+                      [urlValidation]="false" [theme]="theme.mode()"></ng2-pdfjs-viewer>
   </div>
 
   <div controls>

--- a/playground/src/app/pages/sources/sources.component.ts
+++ b/playground/src/app/pages/sources/sources.component.ts
@@ -2,6 +2,7 @@ import { Component, computed, inject, signal } from '@angular/core';
 import { PdfJsViewerComponent, PdfJsViewerModule } from 'ng2-pdfjs-viewer';
 import { CodeGenService } from '../../core/services/code-gen.service';
 import { SamplePdfService } from '../../core/services/sample-pdf.service';
+import { ThemeService } from '../../core/services/theme.service';
 import { PlaygroundLayoutComponent } from '../../shared/playground-layout.component';
 
 @Component({
@@ -18,6 +19,7 @@ import { PlaygroundLayoutComponent } from '../../shared/playground-layout.compon
 export class SourcesComponent {
   private readonly codegen = inject(CodeGenService);
   private readonly samples = inject(SamplePdfService);
+  readonly theme = inject(ThemeService);
 
   readonly kind = signal<'url' | 'blob' | 'bytes'>('url');
   readonly src = signal<string | Blob | Uint8Array>(this.samples.current().src);

--- a/playground/src/app/pages/toolbar/toolbar.component.html
+++ b/playground/src/app/pages/toolbar/toolbar.component.html
@@ -8,6 +8,7 @@
   <div preview>
     <ng2-pdfjs-viewer
       [pdfSrc]="src()"
+      [theme]="theme.mode()"
       [showOpenFile]="showOpenFile()"
       [showDownload]="showDownload()"
       [showPrint]="showPrint()"

--- a/playground/src/app/pages/toolbar/toolbar.component.ts
+++ b/playground/src/app/pages/toolbar/toolbar.component.ts
@@ -3,6 +3,7 @@ import { PdfJsViewerModule } from 'ng2-pdfjs-viewer';
 import { CodeBinding } from '../../core/models';
 import { CodeGenService } from '../../core/services/code-gen.service';
 import { SamplePdfService } from '../../core/services/sample-pdf.service';
+import { ThemeService } from '../../core/services/theme.service';
 import { PlaygroundLayoutComponent } from '../../shared/playground-layout.component';
 
 type Toggle = { key: string; sig: ReturnType<typeof signal<boolean>>; label: string };
@@ -16,6 +17,7 @@ type Toggle = { key: string; sig: ReturnType<typeof signal<boolean>>; label: str
 export class ToolbarComponent {
   private readonly codegen = inject(CodeGenService);
   private readonly samples = inject(SamplePdfService);
+  readonly theme = inject(ThemeService);
   readonly src = computed(() => this.samples.current().src);
 
   readonly showOpenFile = signal(true);

--- a/playground/src/index.html
+++ b/playground/src/index.html
@@ -1,7 +1,21 @@
 <!doctype html>
-<html lang="en" data-theme="dark">
+<html lang="en">
 <head>
   <meta charset="utf-8" />
+  <script>
+    // Resolve the theme before first paint: saved choice > OS preference > dark.
+    (function () {
+      try {
+        var s = localStorage.getItem('pg-theme');
+        var m = (s === 'light' || s === 'dark')
+          ? s
+          : (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+        document.documentElement.setAttribute('data-theme', m);
+      } catch (e) {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      }
+    })();
+  </script>
   <title>ng2-pdfjs-viewer · Playground</title>
   <base href="/" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
## Summary

Two theme-consistency follow-ups for the playground:

- **Respect the OS theme on first visit.** `ThemeService` now resolves the initial theme as *saved choice → `prefers-color-scheme` → dark*, applied without persisting the OS-derived value (so it keeps tracking the OS until you explicitly toggle). An inline script in `index.html` sets `data-theme` before first paint to avoid a flash of the wrong theme.
- **Embedded viewers follow the playground theme.** Every feature page's `<ng2-pdfjs-viewer>` now binds `[theme]` to the playground theme so the viewer chrome matches light/dark. The theming page keeps its own dedicated theme control.

Playground-only — no library source or dependencies are touched. Verified with a production build (Node 24, all pages compile).