### PR TITLE
CI: drop the npm upgrade step (Node 24 bundles npm >= 11.5.1)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,10 @@ jobs:
           # Angular 22 / ng-packagr 22 / TypeScript 6.0 require Node >= 22.22 / 24.15
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
-      # Trusted publishing + provenance require npm >= 11.5.1. Pinned to a fixed
-      # version (not @latest) for a reproducible toolchain (Scorecard Pinned-Dependencies).
-      - name: Upgrade npm
-        run: npm install -g npm@11.17.0
+      # Node 24 (node-version above) already bundles npm >= 11.5.1, which trusted
+      # publishing + provenance require, so no separate npm upgrade step is needed.
+      # (An `npm install -g npm@x` step can't be hash-pinned for Scorecard, so it's
+      # removed rather than left as an unpinned dependency.)
       - name: Install dependencies
         working-directory: ./lib
         run: npm ci


### PR DESCRIPTION
Removes `npm install -g npm@...` from the publish workflow. An npm command can't be pinned by hash, so Scorecard flags it under Pinned-Dependencies. Node 24 (the workflow's `node-version`) already bundles npm 11.13+, which satisfies the trusted-publishing/provenance requirement (>= 11.5.1), making the step unnecessary. CI-only.