### PR TITLE
Fix invisible toolbar icons when viewer theme differs from OS theme

### DIFF
--- a/lib/pdfjs/web/ng2-customization.css
+++ b/lib/pdfjs/web/ng2-customization.css
@@ -166,6 +166,12 @@ body #outerContainer.sidebar-right.viewsManagerOpen #loadingBar {
 /* Light theme defaults */
 .ng2-theme-light,
 .ng2-theme-light-active {
+  /* Pin the UA color-scheme so PDF.js's light-dark() colours (toolbar/menu
+     icons, form controls, scrollbars) resolve to the SELECTED theme instead of
+     the OS preference. Without this, when the app theme differs from the OS
+     theme the icons inherit :root's `color-scheme: light dark` and become
+     invisible (e.g. light icons on a light toolbar). */
+  color-scheme: light;
   --ng2-default-bg: #d4d4d7; /* PDF.js original grey background */
   --ng2-default-text: #000000;
   --ng2-default-toolbar: #f9f9f9;
@@ -175,6 +181,7 @@ body #outerContainer.sidebar-right.viewsManagerOpen #loadingBar {
 /* Dark theme defaults */
 .ng2-theme-dark,
 .ng2-theme-dark-active {
+  color-scheme: dark;
   --ng2-default-bg: #1e1e1e;
   --ng2-default-text: #ffffff;
   --ng2-default-toolbar: #333333;


### PR DESCRIPTION
## Problem (#307)
When the app sets `[theme]` to a value different from the OS theme, the PDF.js toolbar/menu icons become invisible (e.g. light icons on a light toolbar). The 26.0.0 theme work did not resolve it.

## Root cause
PDF.js v6 colours its toolbar/menu icons with the CSS `light-dark()` function, which resolves against the inherited **`color-scheme`** property. PDF.js sets `color-scheme: light dark` on `:root` (i.e. *follow the OS*). Our `.ng2-theme-*` classes set colours but never pinned `color-scheme`, so the icons kept following the OS — and when the app theme differed from the OS, they resolved to the wrong (invisible) variant.

## Fix
Pin `color-scheme` on the theme classes — `light` for `ng2-theme-light(-active)`, `dark` for `ng2-theme-dark(-active)`. The classes live on `<body>`, so the pin cascades to the toolbar/menus (overriding `:root`) while leaving page-content layers — which set their own `color-scheme` — untouched.

## Verified
Reproduced the mismatch in the playground (app `[theme]=dark`, browser `prefers-color-scheme: light`) and confirmed via computed styles: the toolbar `color-scheme` is now `dark` and the icon colour resolves to `rgb(255,255,255)` — visible on the dark toolbar. Symmetric for the reverse case. CSS-only change to the customization layer.