### PR TITLE
Docs: add an Angular PDF Viewer banner to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="https://raw.githubusercontent.com/intbot/ng2-pdfjs-viewer/master/lib/logo.svg" alt="ng2-pdfjs-viewer" width="120" height="140" />
+<img src="https://raw.githubusercontent.com/intbot/ng2-pdfjs-viewer/master/lib/pdf-viewer-banner.svg" alt="Angular PDF Viewer — ng2-pdfjs-viewer" width="560" />
 
 # ng2-pdfjs-viewer
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="https://raw.githubusercontent.com/intbot/ng2-pdfjs-viewer/master/lib/logo.svg" alt="ng2-pdfjs-viewer" width="120" height="140" />
+<img src="https://raw.githubusercontent.com/intbot/ng2-pdfjs-viewer/master/lib/pdf-viewer-banner.svg" alt="Angular PDF Viewer — ng2-pdfjs-viewer" width="560" />
 
 # ng2-pdfjs-viewer
 

--- a/lib/pdf-viewer-banner.svg
+++ b/lib/pdf-viewer-banner.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="200" viewBox="0 0 640 200" role="img" aria-label="Angular PDF Viewer">
+  <defs>
+    <linearGradient id="panel" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b0e16"/>
+      <stop offset="1" stop-color="#161d31"/>
+    </linearGradient>
+    <linearGradient id="ngShield" x1="0" y1="0" x2="0.5" y2="1">
+      <stop offset="0" stop-color="#e40035"/>
+      <stop offset="1" stop-color="#c3002f"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.28" cy="0.5" r="0.6">
+      <stop offset="0" stop-color="#7c5cff" stop-opacity="0.32"/>
+      <stop offset="0.55" stop-color="#22d3ee" stop-opacity="0.09"/>
+      <stop offset="1" stop-color="#22d3ee" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="640" height="200" rx="20" fill="url(#panel)"/>
+  <ellipse cx="180" cy="100" rx="230" ry="150" fill="url(#glow)"/>
+  <!-- Angular shield -->
+  <g transform="translate(78,42) scale(0.46)">
+    <path d="M125 30 L31.9 63.2 L46.1 186.3 L125 230 L203.9 186.3 L218.1 63.2 Z" fill="url(#ngShield)"/>
+    <path d="M125 52.1 L66.8 182.6 L88.5 182.6 L100.2 153.4 L149.6 153.4 L161.3 182.6 L183 182.6 Z M142 135.4 L108 135.4 L125 94.5 Z" fill="#ffffff"/>
+  </g>
+  <text x="232" y="118" font-family="'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="50" font-weight="700" letter-spacing="-1.5" fill="#ffffff">PDF Viewer</text>
+</svg>


### PR DESCRIPTION
Adds a self-contained SVG banner (Angular shield + "PDF Viewer") at the top of the README, replacing the small logo. The SVG includes its own dark backdrop so it renders cleanly on npm's white page and on GitHub light/dark, and uses system fonts so it renders correctly as an `<img>` on both. Verified rendering on white and dark backgrounds. Inert SVG (no scripts/handlers).