### PR TITLE
README badges + refresh demo to 26.0.2 (ships the dark-mode icon fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,17 @@
 
 **A complete PDF experience in one Angular component — view, annotate, sign, fill forms, search, and read aloud, powered by Mozilla PDF.js.**
 
+[![total downloads](https://img.shields.io/badge/total%20downloads-8.3M%2B-22c55e?style=flat-square&logo=npm)](https://www.npmjs.com/package/ng2-pdfjs-viewer)
 [![npm version](https://img.shields.io/npm/v/ng2-pdfjs-viewer?style=flat-square&logo=npm&color=2563eb)](https://www.npmjs.com/package/ng2-pdfjs-viewer)
 [![downloads / month](https://img.shields.io/npm/dm/ng2-pdfjs-viewer?style=flat-square&color=f97316)](https://www.npmjs.com/package/ng2-pdfjs-viewer)
-[![total downloads](https://img.shields.io/badge/total%20downloads-8.3M%2B-22c55e?style=flat-square&logo=npm)](https://www.npmjs.com/package/ng2-pdfjs-viewer)
 [![runtime dependencies](https://img.shields.io/badge/runtime%20deps-0-success?style=flat-square)](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/BILL-OF-MATERIALS.md)
-[![PDF.js](https://img.shields.io/badge/PDF.js-6.0.227-green?style=flat-square&logo=mozilla)](https://github.com/mozilla/pdf.js)
+[![types](https://img.shields.io/npm/types/ng2-pdfjs-viewer?style=flat-square)](https://www.npmjs.com/package/ng2-pdfjs-viewer)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/intbot/ng2-pdfjs-viewer/badge)](https://scorecard.dev/viewer/?uri=github.com/intbot/ng2-pdfjs-viewer)
+[![CodeQL](https://github.com/intbot/ng2-pdfjs-viewer/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/intbot/ng2-pdfjs-viewer/security/code-scanning)
 [![Angular](https://img.shields.io/badge/Angular-%3E%3D10-red?style=flat-square&logo=angular)](https://angular.dev)
+[![PDF.js](https://img.shields.io/badge/PDF.js-6.0.227-green?style=flat-square&logo=mozilla)](https://github.com/mozilla/pdf.js)
 [![license](https://img.shields.io/badge/license-Apache--2.0%20%28Commons%20Clause%29-blue?style=flat-square)](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/LICENSE)
 [![stars](https://img.shields.io/github/stars/intbot/ng2-pdfjs-viewer?style=flat-square&logo=github)](https://github.com/intbot/ng2-pdfjs-viewer)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/intbot/ng2-pdfjs-viewer/badge)](https://scorecard.dev/viewer/?uri=github.com/intbot/ng2-pdfjs-viewer)
 
 [**Live demo**](https://angular-pdf-viewer-demo.vercel.app/) · [**Documentation**](https://angular-pdf-viewer-docs.vercel.app/) · [**API reference**](https://angular-pdf-viewer-docs.vercel.app/docs/api/component-inputs) · [**Changelog**](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 [![downloads / month](https://img.shields.io/npm/dm/ng2-pdfjs-viewer?style=flat-square&color=f97316)](https://www.npmjs.com/package/ng2-pdfjs-viewer)
 [![runtime dependencies](https://img.shields.io/badge/runtime%20deps-0-success?style=flat-square)](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/BILL-OF-MATERIALS.md)
 [![types](https://img.shields.io/npm/types/ng2-pdfjs-viewer?style=flat-square)](https://www.npmjs.com/package/ng2-pdfjs-viewer)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/intbot/ng2-pdfjs-viewer/badge)](https://scorecard.dev/viewer/?uri=github.com/intbot/ng2-pdfjs-viewer)
 [![CodeQL](https://github.com/intbot/ng2-pdfjs-viewer/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/intbot/ng2-pdfjs-viewer/security/code-scanning)
 [![Angular](https://img.shields.io/badge/Angular-%3E%3D10-red?style=flat-square&logo=angular)](https://angular.dev)
 [![PDF.js](https://img.shields.io/badge/PDF.js-6.0.227-green?style=flat-square&logo=mozilla)](https://github.com/mozilla/pdf.js)

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -13271,9 +13271,9 @@
       }
     },
     "node_modules/ng2-pdfjs-viewer": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/ng2-pdfjs-viewer/-/ng2-pdfjs-viewer-26.0.0.tgz",
-      "integrity": "sha512-7WGdnPAfbivH4MzsIMxh5B1rmwm8KdSUrdx1rlZeGaoIceEgI9mEKX31wJihhlMumxzOJoVgEclc/TdT3zCq2A==",
+      "version": "26.0.2",
+      "resolved": "https://registry.npmjs.org/ng2-pdfjs-viewer/-/ng2-pdfjs-viewer-26.0.2.tgz",
+      "integrity": "sha512-4nER40Asy2HOjSM5eM/6jKURG/o9TEEU1JaXMa1rTDe85SxvnJ6Zp5GeCClVz8Q4PvKdReC64vlj0uVnpCuQKw==",
       "license": "Apache-2.0 + Commons Clause",
       "dependencies": {
         "tslib": "^2.3.0"


### PR DESCRIPTION
Two small post-26.0.2 housekeeping changes.

### README badges
- Added **CodeQL** (live code-scanning status; default setup already enabled) and **types: TypeScript**.
- Reordered so the highest-signal badges land top-left: total downloads (8.3M+) → identity → 0-deps/types/security cluster → compatibility → license/stars.
- Deliberately skipped a packagephobia install-size badge — the package is ~8.2 MB unpacked (it bundles the full PDF.js runtime), so that number reads as bloat and fights the 0-runtime-deps story.

### Refresh the live demo to 26.0.2
- `playground/package-lock.json` was pinned to **26.0.0**, so the Vercel demo (which runs `npm ci`) never picked up newer releases — including the #307 theme/OS icon-visibility fix shipped in #334 / 26.0.2.
- Bumps the lock entry to **26.0.2** so the next demo deploy serves the fix.
