### PR TITLE
Docs: human-voice writing rule + guard, and rewrite intro/overview

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell hooks and scripts must stay LF — CRLF breaks the shebang on Linux/macOS.
+.githooks/** text eol=lf
+*.sh text eol=lf

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Keep the docs human: flag AI-generator filler in staged Markdown.
+# Enable once per clone:  git config core.hooksPath .githooks
+# Bypass once (rare):     git commit --no-verify
+if git diff --cached --name-only --diff-filter=ACM | grep -q '\.md$'; then
+  command -v node >/dev/null 2>&1 || { echo "pre-commit: node not found, skipping docs-voice check"; exit 0; }
+  node scripts/check-docs-voice.mjs --staged || exit 1
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,22 @@ published `ng2-pdfjs-viewer` for Vercel builds; `yalc link` overrides it with yo
   additive, backward-compatible changes and document breaking ones in `CHANGELOG.md` / an
   upgrade guide.
 
+## Writing voice (README, docs-website, CHANGELOG, examples)
+
+Public prose must read like a maintainer wrote it, not a content generator. The
+`.githooks/pre-commit` hook runs `node scripts/check-docs-voice.mjs --staged` on staged Markdown
+and blocks generator filler; run it yourself before committing docs (enable the hook once per
+clone with `git config core.hooksPath .githooks`).
+
+- Lead with a specific fact, number, or behavior, not an adjective. Cut filler superlatives
+  (`seamless`, `effortless`, `blazing-fast`, `cutting-edge`, `world-class`). `comprehensive`,
+  `feature-rich`, `AI-enabled`, and `mobile-first` are deliberate positioning — keep those.
+- Keep a real voice: first person where it fits, name trade-offs, state honest limits and constraints.
+- Vary sentence length and shape. Several sections in an identical title-then-one-sentence pattern
+  is the machine's fingerprint; break it up.
+- Don't open with `Welcome to the comprehensive documentation`, `In this guide we'll`, or
+  `Let's dive in`. Keep code examples and concrete constraints; they are what earn a reader's trust.
+
 ## Private working area (`internal/`)
 
 `internal/` is a directory **junction** to a folder in a separate, private sibling repo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,6 +206,26 @@ ng2-pdfjs-viewer/
 - Document all public methods
 - Include type information
 
+### Writing voice
+
+Docs and README copy should read like a maintainer wrote them, not a content generator. A
+pre-commit hook enforces this — enable it once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+It runs `node scripts/check-docs-voice.mjs --staged` and blocks generator filler. The rules:
+
+- Lead with a concrete fact, number, or behavior, not an adjective.
+- Cut filler superlatives (`seamless`, `effortless`, `blazing-fast`, `cutting-edge`, `world-class`).
+  Brand words (`comprehensive`, `feature-rich`, `AI-enabled`, `mobile-first`) are fine to use.
+- Keep a real voice: name trade-offs, state honest limits, write in first person where it fits.
+- Vary sentence length and structure; don't repeat an identical title-then-one-sentence shape.
+- Skip generic openers like `Welcome to the …` or `In this guide we'll`. Keep the code examples.
+
+Run it on specific files anytime: `node scripts/check-docs-voice.mjs README.md docs-website/docs/intro.md`.
+
 ## 🚀 Release Process
 
 ### Version Bumping

--- a/docs-website/docs/features/overview.md
+++ b/docs-website/docs/features/overview.md
@@ -1,93 +1,44 @@
 # Features Overview
 
-ng2-pdfjs-viewer comes packed with powerful features designed for modern Angular applications — bundled Mozilla **PDF.js 6.x**, built and verified on **Angular 22** (peer range stays `>=10`). Here's what makes it special:
+Most of what you reach for in a PDF viewer is a declarative input or output here. Point `pdfSrc` at a file and the component renders, navigates, searches, prints, and zooms with no extra wiring. The table below is the whole feature surface; each row links to a guide with runnable code.
 
-## 🆕 Latest Features
+PDF.js 6.x is bundled, and the component is built and tested on Angular 22 (peer range stays `>=10`).
 
-| Feature | Description | Docs |
-| ------- | ----------- | ---- |
-| **Annotation Editing & eSign** | Highlight, text, draw, stamp + opt-in signature & comment editors, with save/restore (`getAnnotations()`/`setAnnotations()`) and download-with-edits | [Annotation Editing](./annotation-editing) |
-| **Forms & Data** | `[(formData)]` two-way AcroForm binding, programmatic read/write, save filled documents | [Forms](./forms) |
-| **Programmatic Search** | `search()` API with totals, per-page counts and next/prev stepping | [Search](./search) |
-| **Page Organization** | Reorder, delete, extract and merge pages in the viewer (opt-in) | [Page Organization](./page-organization) |
-| **AI Assistant (BYO endpoint)** | Built-in chat panel with clickable page citations against **your** OpenAI-compatible endpoint — zero vendor calls | [AI Assistant](./ai-assistant) |
-| **Read Aloud** | Sentence-by-sentence text-to-speech with in-page highlighting | [Read Aloud](./read-aloud) |
-| **Custom Toolbar, Sidebar & Overlays** | Replace viewer chrome with your Angular templates; project templates onto every page | [Custom UI](./custom-ui) |
-| **Content Protection** | Block print/download/text-selection + watermarks (honest client-side deterrence, not DRM) | [Content Protection](./content-protection) |
-| **Authenticated Loading** | `httpHeaders`/`withCredentials` + download progress + password-prompt events | [Loading Documents](./loading-documents) |
-| **Accessibility (WCAG/EAA)** | Screen-reader text layer, tagged-PDF structure, keyboard chrome, read-aloud | [Accessibility](./accessibility) |
-| **True Dark Pages** | Re-render page content with custom colors (`pageColors`) — dark mode beyond chrome | [Theming](./theming) |
-| **PDF.js Options Passthrough** | Allowlisted `pdfJsOptions` for init-time viewer preferences | [Component Inputs](../api/component-inputs) |
+## Features
 
-## Foundation (v25.x rewrite)
+| Feature | What it does | Guide |
+| ------- | ------------ | ----- |
+| **Annotation editing & eSign** | Highlight, text, draw, stamp, plus opt-in signature & comment editors. Save and restore with `getAnnotations()`/`setAnnotations()`; download with edits applied. | [Annotation editing](./annotation-editing) |
+| **Forms** | Two-way `[(formData)]` AcroForm binding, programmatic read/write, save filled documents. | [Forms](./forms) |
+| **Search** | `search()` with totals, per-page counts, and next/previous stepping. | [Search](./search) |
+| **Page organization** | Reorder, delete, extract, and merge pages in the viewer (opt-in). | [Page organization](./page-organization) |
+| **AI assistant (your endpoint)** | Chat panel with clickable page citations against your OpenAI-compatible endpoint. The library makes no vendor calls of its own. | [AI assistant](./ai-assistant) |
+| **Read aloud** | Sentence-by-sentence text-to-speech with in-page highlighting. | [Read aloud](./read-aloud) |
+| **Custom toolbar, sidebar & overlays** | Replace the viewer chrome with your Angular templates; project templates onto every page. | [Custom UI](./custom-ui) |
+| **Content protection** | Block print, download, and text selection; stamp watermarks. Client-side deterrence, not DRM. | [Content protection](./content-protection) |
+| **Authenticated loading** | `httpHeaders`/`withCredentials`, download progress, password-prompt events. | [Loading documents](./loading-documents) |
+| **Localization** | Locale detection, RTL, and overridable UI strings via `locale`. | [Component inputs](../api/component-inputs) |
+| **Accessibility (WCAG/EAA)** | Screen-reader text layer, tagged-PDF structure, keyboard chrome, read-aloud. | [Accessibility](./accessibility) |
+| **True dark pages** | Re-render page content with custom colors via `pageColors`, not just the chrome. | [Theming](./theming) |
+| **PDF.js options passthrough** | Allowlisted `pdfJsOptions` for init-time viewer preferences. | [Component inputs](../api/component-inputs) |
 
-| Feature | Description | Status |
-| ------- | ----------- | ------ |
-| **Complete Rewrite** | Full library rewrite with modern Angular patterns | ✅ |
-| **Advanced Theme System** | CSS custom properties for complete visual customization | ✅ |
-| **Template-Based UI** | Custom loading spinners and error displays using Angular templates | ✅ |
-| **Convenience Configuration** | Object-based configuration for cleaner, more maintainable code | ✅ |
-| **Event-Driven Architecture** | Pure event-based system with universal action dispatcher | ✅ |
-| **Enhanced Error Handling** | Multiple error display styles with custom templates | ✅ |
-| **Mobile-First Design** | Responsive layout optimized for touch devices | ✅ |
-| **TypeScript Strict Mode** | Full type safety with comprehensive API coverage | ✅ |
-| **URL Security Validation** | Prevents unauthorized file parameter manipulation with custom templates | ✅ |
+## How it's built
 
-## 🏆 Unique Advantages
+A few design choices worth knowing before you wire it up:
 
-### Universal Action Dispatcher
-Single pathway for all actions with readiness validation. No more timing issues or race conditions.
+- **One action path, no polling.** Every method call (go to page, set zoom, start read-aloud) is queued and runs once the viewer reports it's ready, so calls made before the PDF finishes loading don't get dropped or race the load. This replaced the timeout-based approach from v20.
+- **Templates, not HTML strings.** Loading spinners, error states, the toolbar, the sidebar, and per-page overlays are `<ng-template>`s you supply, so they keep your bindings and pass through Angular's sanitizer.
+- **A typed surface.** 30+ inputs, 24+ outputs, and 19+ Promise-returning methods, all typed. The [API reference](../api/component-inputs) is the full list.
+- **One same-origin iframe.** The bundled PDF.js viewer runs in a sandboxed, same-origin iframe, and the host-to-viewer `postMessage` bridge checks `event.source` in both directions. See [iframe security](./iframe-security).
 
-### Template-Based Customization
-Use Angular templates for loading and error states instead of HTML strings. More secure and maintainable.
+## Theming
 
-### Comprehensive Event System
-24+ events covering all user interactions and state changes. Build reactive applications with confidence.
+Pass a theme object, or drive it all with CSS variables:
 
-### Advanced Configuration Objects
-Clean, object-based configuration for complex setups. Group related settings logically.
-
-### Production-Ready Architecture
-Event-driven design with no timeouts or polling. Built for enterprise applications.
-
-## 📱 Mobile & Responsive
-
-### Touch-Friendly Interface
-- Optimized touch gestures
-- Responsive toolbar layout
-- Mobile-first design approach
-- Adaptive UI components
-
-### Screen Size Adaptations
-- Automatic layout adjustments
-- Collapsible toolbars
-- Responsive sidebar
-- Mobile navigation patterns
-
-## 🎨 Theming & Customization
-
-### Advanced Theme System
 ```typescript
-themeConfig = {
-  theme: 'dark',
-  primaryColor: '#3f51b5',
-  backgroundColor: '#1e1e1e',
-  textColor: '#ffffff'
-};
+themeConfig = { theme: 'dark', primaryColor: '#3f51b5', backgroundColor: '#1e1e1e', textColor: '#ffffff' };
 ```
 
-### Custom Templates
-```html
-<ng-template #loadingTemplate>
-  <div class="custom-loader">
-    <mat-spinner></mat-spinner>
-    <p>Loading your document...</p>
-  </div>
-</ng-template>
-```
-
-### CSS Custom Properties
-Complete visual control through CSS variables:
 ```css
 :root {
   --pdf-viewer-primary: #3f51b5;
@@ -96,115 +47,11 @@ Complete visual control through CSS variables:
 }
 ```
 
-## ⚡ Performance Features
+Dark mode can re-render the page content itself, not just the toolbar, with `pageColors`. The [theming guide](./theming) has the full set.
 
-### Event-Driven Architecture
-- No polling or timeouts
-- Immediate action execution
-- Efficient memory usage
-- Optimized rendering pipeline
+## Next
 
-### Lazy Loading
-- On-demand resource loading
-- Progressive PDF rendering
-- Memory-efficient page handling
-- Optimized for large documents
-
-### Caching & Optimization
-- Intelligent resource caching
-- Minimized re-renders
-- Efficient event handling
-- Optimized bundle size
-
-## 🔧 Developer Experience
-
-### TypeScript Support
-- Full type safety with strict mode
-- Comprehensive type definitions
-- IntelliSense support
-- Compile-time error checking
-
-### Event System
-- 24+ comprehensive events
-- Strongly typed event data
-- Consistent event patterns
-- Easy event handling
-
-### API Methods
-- 19+ methods with Promise returns
-- Consistent error handling
-- Comprehensive method coverage
-- Easy programmatic control
-
-### Debugging Support
-- Built-in diagnostic logging
-- Error tracking and reporting
-- Development mode helpers
-- Clear error messages
-
-## 📊 Advanced Features
-
-### Multi-Language Support
-- Automatic locale detection
-- RTL language support
-- Customizable text strings
-- International number formats
-
-### Accessibility
-- ARIA label support
-- Keyboard navigation
-- Screen reader compatibility
-- High contrast mode support
-
-### Security
-- XSS prevention
-- Content sanitization
-- Secure template rendering
-- CORS handling
-
-### Browser Compatibility
-- Modern browser support
-- Progressive enhancement
-- Fallback mechanisms
-- Cross-platform consistency
-
-## 🔄 Migration Benefits
-
-### From v20.x to v25.x
-- **Cleaner API**: Simplified configuration
-- **Better Performance**: Event-driven architecture
-- **Enhanced Security**: Template-based UI
-- **Improved DX**: Better TypeScript support
-- **Modern Patterns**: Angular best practices
-
-## 🎯 Perfect For
-
-- **Document Management Systems**
-- **E-learning Platforms**
-- **Report Viewers**
-- **Digital Publishing**
-- **Enterprise Applications**
-- **Mobile Applications**
-
-## 🔒 Security Features
-
-### URL Validation
-Prevents unauthorized file parameter manipulation in external viewer mode. When enabled, the component validates that the file parameter in the viewer URL hasn't been tampered with.
-
-### Custom Security Templates
-Use Angular templates to display custom security warnings when URL manipulation is detected.
-
-### Developer-Friendly
-Console warnings for debugging while maintaining user experience.
-
-## What's Next?
-
-Explore specific features in detail:
-
-- 🎨 [**Theming**](./theming) - Customize the appearance
-- 🔒 [**Security**](./security) - URL validation and security features
-- 🛡️ [**iframe Security**](./iframe-security) - iframe sandbox and security configuration
-- 🪟 [**External Window**](./external-window) - External window and tab management
-- 📚 [**Examples**](../examples/basic-usage) - See it in action
-- 📖 [**API Reference**](../api/component-inputs) - Complete documentation
-- 🔄 [**Migration Guide**](../migration/overview) - Upgrade from v20.x
+- [Theming](./theming), [security](./security), and [iframe security](./iframe-security)
+- [External window](./external-window) for new-tab and popout viewers
+- [Examples](../examples/basic-usage) and the [API reference](../api/component-inputs)
+- [Migration from v20.x](../migration/overview)

--- a/docs-website/docs/intro.md
+++ b/docs-website/docs/intro.md
@@ -1,91 +1,46 @@
-# Welcome to ng2-pdfjs-viewer
+# ng2-pdfjs-viewer
 
-Welcome to the comprehensive documentation for **ng2-pdfjs-viewer** - the most reliable and feature-rich Angular PDF viewer component powered by Mozilla's PDF.js.
-
-## What's New 🎉
-
-The latest release bundles Mozilla **PDF.js 6.x**, is built and verified on **Angular 22** (peer range stays `>=10`), and turns the viewer into a full editing surface:
-
-- **Annotation editing & eSign**: highlight, text, draw, stamp + opt-in signature and comment editors — with `getAnnotations()`/`setAnnotations()` server round-trips and download-with-edits
-- **Forms**: `[(formData)]` two-way AcroForm binding and programmatic field access
-- **Programmatic search**, **page organization** (reorder/delete/extract/merge), **read aloud** with sentence highlighting
-- **AI assistant (bring your own endpoint)**: built-in chat panel with clickable page citations — the library never calls any AI service on its own
-- **Custom toolbar/sidebar/page-overlay templates**, **content protection + watermarks**, **authenticated loading** (`httpHeaders`/`withCredentials`), **true dark page rendering**
-
-### 🚀 Architecture (v25.x rewrite)
-
-- **Modern Architecture**: Built with modern Angular patterns (verified through Angular 22) and strict TypeScript
-- **Event-Driven**: Pure event-based system with universal action dispatcher
-- **Template-Based**: Use Angular templates for loading and error states
-- **Mobile-First**: Responsive design optimized for all screen sizes
-- **Production-Ready**: Comprehensive error handling and performance optimization
-
-### 📈 Battle-Tested Reliability
-
-- **Born in 2018** and still going strong
-- **8.3+ million downloads** and growing
-- **8+ years** of continuous development
-- **Thousands** of applications powered worldwide
-
-## Quick Links
-
-- 🚀 [**Getting Started**](./getting-started) - Set up in 5 minutes
-- 🎯 [**Live Demo**](https://angular-pdf-viewer-demo.vercel.app/) - See it in action
-- 📚 [**Examples**](./examples/basic-usage) - Copy-paste code examples
-- 🔄 [**Migration Guide**](./migration/overview) - Upgrade from v20.x
-- 📖 [**API Reference**](./api/component-inputs) - Complete API documentation
-
-## Installation
-
-Get started quickly with npm:
+ng2-pdfjs-viewer wraps Mozilla PDF.js in a single Angular component. It has been on npm since 2018, has passed more than 8.3 million downloads, and still supports Angular 10 through 22 with zero runtime dependencies. It's the same one-tag component it has always been, with annotations, forms, search, page editing, read-aloud, and a bring-your-own AI panel layered on in v26.
 
 ```bash
-npm install ng2-pdfjs-viewer --save
+npm install ng2-pdfjs-viewer
 ```
-
-## Basic Usage
 
 ```typescript
 import { PdfJsViewerModule } from 'ng2-pdfjs-viewer';
 
-@NgModule({
-  imports: [PdfJsViewerModule],
-})
+@NgModule({ imports: [PdfJsViewerModule] })
 export class AppModule {}
 ```
 
 ```html
-<ng2-pdfjs-viewer 
-  pdfSrc="assets/sample.pdf" 
-  [showSpinner]="true">
-</ng2-pdfjs-viewer>
+<ng2-pdfjs-viewer pdfSrc="assets/sample.pdf" [showSpinner]="true"></ng2-pdfjs-viewer>
 ```
 
-The `pdfSrc` property accepts URLs (strings), Blob objects, or Uint8Array byte arrays.
+`pdfSrc` takes a URL, a `Blob`, a `Uint8Array`, or an `ArrayBuffer`. Point the component at a file, serve the bundled PDF.js assets (the [Getting Started](./getting-started) guide covers the one-time `angular.json` step), and you have a working viewer.
 
-That's it! Your PDF viewer is ready to use.
+## What's in v26
 
-## Why the Rewrite?
+PDF.js 6.x is bundled, and the component is built and tested on Angular 22 while the peer range stays `>=10`. Beyond plain viewing:
 
-The v25.x rewrite addresses key architectural challenges:
+- **Annotation editing and eSign.** Highlight, free-text, draw, and stamp editors, plus opt-in signature and comment editors. `getAnnotations()` and `setAnnotations()` round-trip edits through your server, and `getDocumentAsBlob()` hands back the document with edits baked in.
+- **Forms.** Two-way `[(formData)]` AcroForm binding and programmatic field access.
+- **Search, page organization, and read-aloud.** A `search()` API with per-page counts; reorder, delete, extract, and merge pages; sentence-by-sentence text-to-speech that highlights the words as it reads them.
+- **AI assistant.** A built-in chat panel that talks to *your* OpenAI-compatible endpoint and cites pages you can click through to. The library never calls an AI service on its own.
+- **And the rest.** Custom toolbar, sidebar, and per-page overlay templates; content protection with watermarks; authenticated loading via `httpHeaders` and `withCredentials`; true dark-mode page rendering.
 
-### Before (v20.x)
-- Mixed event/polling patterns
-- Defensive programming
-- Limited customization
-- Complex integration
+Each has its own guide under [Features](./features/overview).
 
-### After (v25.x)
-- Pure event-driven architecture
-- Trust-based execution
-- Template-based customization
-- Simple, clean API
+## About the v25 rewrite
 
-## Community & Support
+v25 replaced the old mix of events and polling with one event-driven path. Every action now waits for the viewer to report it's ready instead of guessing with a timeout, so a call made the instant the component appears no longer races the PDF load. Loading and error states became Angular templates rather than HTML strings, and the public surface is typed end to end. Coming from v20, the [migration guide](./migration/overview) lists the input renames; most apps need only a handful.
 
-- 🐛 **Issues**: [GitHub Issues](https://github.com/intbot/ng2-pdfjs-viewer/issues)
-- 💬 **Discussions**: [GitHub Discussions](https://github.com/intbot/ng2-pdfjs-viewer/discussions)
-- 📚 **Documentation**: You're reading it!
-- 🎯 **Live Demo**: [Vercel Demo](https://angular-pdf-viewer-demo.vercel.app/)
+## Links
 
-Ready to get started? Head over to the [Getting Started](./getting-started) guide!
+- [Getting Started](./getting-started): install, assets, and your first viewer
+- [Live demo](https://angular-pdf-viewer-demo.vercel.app/)
+- [Examples](./examples/basic-usage): copy-paste starting points
+- [API reference](./api/component-inputs): every input, output, and method
+- [Migration from v20.x](./migration/overview)
+
+Bugs and questions go to [GitHub Issues](https://github.com/intbot/ng2-pdfjs-viewer/issues); design discussion to [GitHub Discussions](https://github.com/intbot/ng2-pdfjs-viewer/discussions).

--- a/scripts/check-docs-voice.mjs
+++ b/scripts/check-docs-voice.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// check-docs-voice.mjs — flags "reads as AI-generated" tells in Markdown.
+//
+// Usage:
+//   node scripts/check-docs-voice.mjs --staged        # scan added lines of staged *.md (pre-commit)
+//   node scripts/check-docs-voice.mjs <file.md> ...    # scan whole files (manual / leak-guard)
+//
+// Two tiers:
+//   BLOCK — hype/filler with ~no place in honest docs. Exit 1 (fails the commit).
+//   WARN  — softer or brand-adjacent tells. Printed, never blocks.
+//
+// Brand language is intentional and NOT flagged: "comprehensive", "feature-rich",
+// "AI-enabled", "mobile-first", "#1". Keep those. The point is to kill generator
+// filler, not our positioning. Tune the lists below as the docs evolve.
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const BLOCK = [
+  [/\bblazing[\s-]?fast\b/i, 'hype: "blazing fast"'],
+  [/\bworld[\s-]?class\b/i, 'hype: "world-class"'],
+  [/\bgame[\s-]?chang(ing|er)\b/i, 'hype: "game-changing"'],
+  [/\bcutting[\s-]?edge\b/i, 'hype: "cutting-edge"'],
+  [/\bbest[\s-]?in[\s-]?class\b/i, 'hype: "best-in-class"'],
+  [/\bnext[\s-]?level\b/i, 'hype: "next-level"'],
+  [/\bsupercharg/i, 'hype: "supercharge"'],
+  [/\bunleash/i, 'hype: "unleash"'],
+  [/\bseamless(ly)?\b/i, 'filler: "seamless"'],
+  [/\beffortless(ly)?\b/i, 'filler: "effortless"'],
+  [/\brevolutioniz/i, 'hype: "revolutionize"'],
+  [/\bharness the power\b/i, 'cliché: "harness the power"'],
+  [/\bsay goodbye to\b/i, 'cliché: "say goodbye to"'],
+  [/\blook no further\b/i, 'cliché: "look no further"'],
+  [/\belevate your\b/i, 'cliché: "elevate your"'],
+  [/\bdive (in|into)\b/i, 'filler: "dive in/into"'],
+  [/\bwelcome to the (comprehensive )?(documentation|docs)\b/i, 'generic opener: "Welcome to the … documentation"'],
+  [/\bin this (guide|article|tutorial|section),? we['’]?ll\b/i, 'tutorial filler: "in this guide we\'ll"'],
+  [/\bby the end of this\b/i, 'tutorial filler: "by the end of this"'],
+  [/\bwhether you['’]?re\b.*\bor\b/i, 'opener cliché: "whether you\'re X or Y"'],
+];
+
+const WARN = [
+  [/\bproduction[\s-]?ready\b/i, 'soft superlative: "production-ready"'],
+  [/\bpacked with\b/i, 'marketing: "packed with"'],
+  [/\bdesigned for modern\b/i, 'marketing: "designed for modern"'],
+  [/\b(a )?(rich|wide) (set|range|array) of\b/i, 'marketing: "rich set of"'],
+  [/\bplethora\b/i, 'marketing: "plethora"'],
+  [/\bout[\s-]?of[\s-]?the[\s-]?box\b/i, 'cliché: "out of the box"'],
+  [/\b(powerful|robust)\b/i, 'generic adjective (prefer a concrete fact)'],
+];
+
+const EMDASH_WARN = 4; // per file's scanned content
+
+function stagedAddedLines() {
+  let out = '';
+  try {
+    out = execSync('git diff --cached --unified=0 --no-color -- "*.md"', { encoding: 'utf8' });
+  } catch {
+    return [];
+  }
+  const rows = [];
+  let file = null;
+  let newLine = 0;
+  for (const raw of out.split('\n')) {
+    if (raw.startsWith('+++ ')) { file = raw.slice(4).replace(/^b\//, ''); continue; }
+    if (raw.startsWith('--- ')) continue;
+    const h = raw.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    if (h) { newLine = parseInt(h[1], 10); continue; }
+    if (raw.startsWith('+')) { rows.push({ file, line: newLine, text: raw.slice(1) }); newLine++; }
+  }
+  return rows;
+}
+
+function wholeFileLines(files) {
+  const rows = [];
+  for (const f of files) {
+    let txt;
+    try { txt = readFileSync(f, 'utf8'); } catch { continue; }
+    txt.split('\n').forEach((text, i) => rows.push({ file: f, line: i + 1, text }));
+  }
+  return rows;
+}
+
+const args = process.argv.slice(2);
+const rows = args.includes('--staged')
+  ? stagedAddedLines()
+  : wholeFileLines(args.filter((a) => !a.startsWith('--')));
+
+const blocks = [];
+const warns = [];
+const emdash = new Map();
+let inFence = false;
+let curFile = null;
+for (const { file, line, text } of rows) {
+  if (file !== curFile) { curFile = file; inFence = false; }
+  if (/^\s*(```|~~~)/.test(text)) { inFence = !inFence; continue; } // fenced code block toggle
+  if (inFence) continue;
+  if (/^\s{4,}\S/.test(text)) continue; // indented code block
+  const prose = text.replace(/`[^`]*`/g, ''); // ignore inline code (e.g. a list of banned words shown as `code`)
+  for (const [re, label] of BLOCK) if (re.test(prose)) blocks.push({ file, line, label, text: text.trim() });
+  for (const [re, label] of WARN) if (re.test(prose)) warns.push({ file, line, label, text: text.trim() });
+  const dashes = (prose.match(/—/g) || []).length;
+  if (dashes) emdash.set(file, (emdash.get(file) || 0) + dashes);
+}
+
+const fmt = (f) => `  ${f.file}:${f.line}  ${f.label}\n      ${f.text.slice(0, 100)}`;
+if (!rows.length) { console.log('docs-voice: nothing to scan.'); process.exit(0); }
+
+if (warns.length || [...emdash.values()].some((n) => n >= EMDASH_WARN)) {
+  console.log('\n⚠ docs-voice WARN (review, not blocking):');
+  warns.forEach((w) => console.log(fmt(w)));
+  for (const [f, n] of emdash) if (n >= EMDASH_WARN) console.log(`  ${f}  em-dash density: ${n} — prefer periods/commas`);
+}
+if (blocks.length) {
+  console.log('\n✗ docs-voice BLOCK (generator filler — rewrite before committing):');
+  blocks.forEach((b) => console.log(fmt(b)));
+  console.log('\nSee the writing rule in CONTRIBUTING.md / CLAUDE.md. Bypass once with `git commit --no-verify`.\n');
+  process.exit(1);
+}
+console.log(`docs-voice: clean${warns.length ? ' (warnings above)' : ''}.`);
+process.exit(0);


### PR DESCRIPTION
Two parts: a standard that keeps the docs reading like a maintainer wrote them, and the first rewrite pass against it.

### Writing rule + guard
- `scripts/check-docs-voice.mjs` flags generator filler in Markdown — blocks hype and canned openers, warns on soft superlatives and em-dash density. Brand words (`comprehensive`, `feature-rich`, `AI-enabled`, `mobile-first`) and inline-code examples are exempt, so the rule docs don't trip their own check.
- `.githooks/pre-commit` runs it on staged `.md`. Enable once per clone: `git config core.hooksPath .githooks`.
- The rule is written into `CLAUDE.md` and `CONTRIBUTING.md`; `.gitattributes` pins LF for the hook so it works on Linux/macOS clones.

### Phase 1 rewrites
- `intro.md` and `features/overview.md` rewritten in a maintainer voice: dropped the generic openers, emoji-header monotony, and content-free bullet padding (`overview.md` 211 → 57 lines). Kept the feature table, links, and code examples; added the real design rationale (queued action path, templates over HTML strings, same-origin iframe).
- README left unchanged — it already passes the guard and reads human; editing prose that's fine is the churn this rule exists to prevent.

Both rewritten files pass the new checker.