### PR TITLE
Docs Phase 2: factual changelog, drop stray superlatives

### DIFF
--- a/docs-website/docs/changelog.md
+++ b/docs-website/docs/changelog.md
@@ -1,223 +1,36 @@
-# What's New 🎉
+# Changelog
 
-## Latest Release Highlights
+This page highlights what's new. The full, version-by-version record (including patch releases) lives in [CHANGELOG.md](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/CHANGELOG.md) on GitHub.
 
-The latest release upgrades the engine and turns the viewer into a full editing surface:
+## Latest release
 
-- **PDF.js 6.x** bundled (from the 5.x line) — all component APIs work unchanged. Note: the PDF.js 6 modern build raises the browser floor; Safari is only supported by PDF.js's legacy build, which this package does not ship
-- **Angular 22 verified** — library built on ng-packagr 22 / TypeScript 6; peer dependencies stay wide (`>=10`, links on Angular 14+)
-- **Annotation editing & eSign**: highlight, text, draw, stamp + opt-in signature and comment editors; persistence via [`getAnnotations()` / `setAnnotations()`](./features/annotation-editing) and download-with-edits (`getDocumentAsBlob()`)
-- **[Forms](./features/forms)**: `[(formData)]` two-way binding, programmatic field access
-- **[Programmatic search](./features/search)**, **[page organization](./features/page-organization)**, **[read aloud](./features/read-aloud)** with sentence highlighting
-- **[AI assistant](./features/ai-assistant)** — bring-your-own OpenAI-compatible endpoint with clickable page citations; the library never calls any AI service on its own
-- **[Custom toolbar, sidebar & page overlays](./features/custom-ui)**, **[content protection](./features/content-protection)** with watermarks, **[authenticated loading](./features/loading-documents)**, true dark page rendering, and four new viewer events (`onSidebarViewChanged`, `onLayersChanged`, `onNamedAction`, `onDocumentProperties`)
+The current line upgrades the engine and turns the viewer into a full editing surface:
 
-Behavior changes to review when upgrading: `showAnnotations` now defaults to `true`; external PDF links open in a new tab by default (`externalLinkTarget`, with `allow-popups` added to the iframe sandbox); `zoomChange` emits named presets (`page-fit`, `page-width`, `auto`) instead of raw numbers for preset zooms.
+- **PDF.js 6.x bundled** (up from the 5.x line); existing component APIs are unchanged. The PDF.js 6 modern build raises the browser floor: Safari needs PDF.js's legacy build, which this package doesn't ship.
+- **Built and tested on Angular 22** (ng-packagr 22 / TypeScript 6); the peer range stays wide at `>=10`.
+- **[Annotation editing & eSign](./features/annotation-editing)**: highlight, text, draw, stamp, plus opt-in signature and comment editors. `getAnnotations()`/`setAnnotations()` persistence and download-with-edits via `getDocumentAsBlob()`.
+- **[Forms](./features/forms)**: `[(formData)]` two-way binding and programmatic field access.
+- **[Search](./features/search)**, **[page organization](./features/page-organization)**, and **[read aloud](./features/read-aloud)** with sentence highlighting.
+- **[AI assistant](./features/ai-assistant)**: your own OpenAI-compatible endpoint, with clickable page citations. The library never calls an AI service on its own.
+- **[Custom toolbar, sidebar & overlays](./features/custom-ui)**, **[content protection](./features/content-protection)** with watermarks, **[authenticated loading](./features/loading-documents)**, true dark page rendering, and four new events (`onSidebarViewChanged`, `onLayersChanged`, `onNamedAction`, `onDocumentProperties`).
 
----
+**Behavior changes to check when upgrading:** `showAnnotations` now defaults to `true`; external PDF links open in a new tab by default (`externalLinkTarget`, with `allow-popups` added to the iframe sandbox); `zoomChange` emits named presets (`page-fit`, `page-width`, `auto`) instead of raw numbers for preset zooms.
 
-## v25.x — The Complete Rewrite
+## v25: the ground-up rewrite
 
-Version 25.x marks a **complete rewrite** of ng2-pdfjs-viewer with modern Angular patterns, enhanced performance, and a focus on developer experience.
+After years of incremental change, v25 rebuilt the component on modern Angular. The visible differences:
 
-:::tip Major Release
-This is a **major release** with breaking changes. Please review the [Migration Guide](./migration/overview) for upgrade instructions.
-:::
+- **One event-driven action path.** Every method waits for a five-level readiness signal instead of polling with timeouts, which removed the race conditions that came from calling methods before the PDF finished loading.
+- **Angular templates instead of HTML strings** for spinners, error states, and chrome, so custom UI keeps its bindings and goes through Angular's sanitizer.
+- **A typed, Promise-based API** end to end.
 
-## 🚀 Complete Rewrite
+It is a major release with breaking changes. The renamed inputs and methods:
 
-### Why a Rewrite?
-After 8 years of evolution, we decided to rebuild ng2-pdfjs-viewer from scratch to:
-- Adopt modern Angular patterns and best practices
-- Improve performance with event-driven architecture
-- Enhance security with template-based UI
-- Provide better TypeScript support
-- Ensure long-term maintainability
+| Old | New |
+|-----|-----|
+| `[startDownload]` | `[downloadOnLoad]` |
+| `[startPrint]` | `[printOnLoad]` |
+| `[errorHtml]` / `setErrorHtml()` | `[customErrorTpl]` |
+| `[spinnerHtml]` / `setSpinnerHtml()` | `[customSpinnerTpl]` |
 
-### Architecture Improvements
-- **Event-Driven**: Pure event-based system with universal action dispatcher
-- **Trust-Based**: Eliminated defensive programming patterns
-- **Single File Integration**: All customizations in one file for easy PDF.js upgrades
-- **Readiness Hierarchy**: 5-level readiness system for reliable action execution
-
-## ✨ New Features
-
-### Template-Based UI
-Replace HTML strings with Angular templates for better security and maintainability:
-
-```html
-<ng-template #loadingTemplate>
-  <div class="custom-loader">
-    <mat-spinner></mat-spinner>
-    <p>Loading your document...</p>
-  </div>
-</ng-template>
-
-<ng2-pdfjs-viewer [customSpinnerTpl]="loadingTemplate">
-</ng2-pdfjs-viewer>
-```
-
-### Advanced Theme System
-Complete visual customization through CSS custom properties:
-
-```typescript
-themeConfig = {
-  theme: 'dark',
-  primaryColor: '#3f51b5',
-  backgroundColor: '#1e1e1e',
-  textColor: '#ffffff'
-};
-```
-
-### Convenience Configuration
-Object-based configuration for cleaner code:
-
-```typescript
-groupVisibility = {
-  "download": true,
-  "print": true,
-  "find": true,
-  "fullScreen": true,
-  "openFile": true,
-  "viewBookmark": true,
-  "annotations": false
-};
-```
-
-### Enhanced Event System
-24+ events covering all user interactions:
-- `onDocumentLoad` - Document loaded successfully
-- `onDocumentError` - Document failed to load
-- `onPageChange` - Page navigation
-- `onZoomChange` - Zoom level changed
-- `onRotationChange` - Document rotated
-- `onProgress` - Loading progress
-- And many more...
-
-### Mobile-First Design
-- Touch-friendly interface
-- Responsive layout
-- Adaptive toolbar
-- Mobile navigation patterns
-
-## 🔧 Technical Improvements
-
-### TypeScript Strict Mode
-- Full type safety throughout the codebase
-- Comprehensive type definitions
-- Better IntelliSense support
-- Compile-time error checking
-
-### Performance Enhancements
-- **No Polling**: Eliminated all setTimeout/setInterval usage
-- **Event-Driven**: Immediate action execution when ready
-- **Memory Efficient**: Optimized resource management
-- **Faster Loading**: Improved initialization sequence
-
-### Security Improvements
-- **XSS Prevention**: Template-based UI prevents injection attacks
-- **Content Sanitization**: Secure handling of user content
-- **CORS Handling**: Better cross-origin request management
-
-### Developer Experience
-- **Promise-Based API**: All methods return promises
-- **Consistent Error Handling**: Unified error management
-- **Better Debugging**: Enhanced logging and error messages
-- **Comprehensive Documentation**: Complete API reference
-
-## 📊 Updated Dependencies
-
-### Core Dependencies
-- **PDF.js**: Updated to v5.3.93 (latest)
-- **Angular**: Support for Angular 20+ (optimized) and 10+ (compatible)
-- **TypeScript**: Support for TypeScript 5.0+
-
-### Build Tools
-- **ng-packagr**: Updated to latest version
-- **Build Process**: Streamlined and optimized
-- **Testing**: Enhanced test coverage
-
-## 🗑️ Deprecated Features
-
-The following features are deprecated and will be removed in future versions:
-
-### Deprecated Properties
-| Deprecated | Replacement | Notes |
-|-----------|-------------|--------|
-| `[startDownload]` | `[downloadOnLoad]` | Clearer naming |
-| `[startPrint]` | `[printOnLoad]` | Clearer naming |
-| `[errorHtml]` | `[customErrorTpl]` | Template-based |
-| `[spinnerHtml]` | `[customSpinnerTpl]` | Template-based |
-
-### Deprecated Methods
-| Deprecated | Replacement | Notes |
-|-----------|-------------|--------|
-| `setErrorHtml()` | Use `[customErrorTpl]` | Template-based |
-| `setSpinnerHtml()` | Use `[customSpinnerTpl]` | Template-based |
-
-## 🔄 Breaking Changes
-
-### Major Breaking Changes
-1. **Template-Based UI**: HTML string properties replaced with template inputs
-2. **Event System**: Enhanced event data structures
-3. **Configuration**: Some properties renamed for clarity
-4. **API Methods**: Updated method signatures for consistency
-
-### Migration Path
-We've provided comprehensive migration documentation:
-- [Migration Overview](./migration/overview)
-- [Getting Started](./getting-started)
-- [Examples](./examples/basic-usage)
-
-## 📈 Performance Benchmarks
-
-### Before vs After (v20.x → v25.x)
-- **Initial Load Time**: 40% faster
-- **Memory Usage**: 25% reduction
-- **Event Response**: 60% faster
-- **Bundle Size**: 15% smaller
-
-### Reliability Improvements
-- **Zero Timeouts**: Eliminated all polling-based code
-- **Race Conditions**: Solved through readiness hierarchy
-- **Error Recovery**: Enhanced error handling and recovery
-- **Memory Leaks**: Comprehensive cleanup on destroy
-
-## 🌟 Community Highlights
-
-### Downloads & Usage
-- **8.3+ Million Downloads**: Trusted by thousands of applications
-- **8+ Years**: Continuous development since 2018
-- **Global Usage**: Applications worldwide
-- **Enterprise Adoption**: Used in production systems
-
-### Community Contributions
-- Bug reports and feature requests
-- Community discussions and support
-- Documentation improvements
-- Testing and feedback
-
-## 🙏 Acknowledgments
-
-### Special Thanks
-- **Mozilla PDF.js Team**: For the amazing PDF.js library
-- **Angular Team**: For the excellent framework
-- **Community Contributors**: For bug reports, feature requests, and contributions
-- **8.3+ Million Users**: For trusting us with your PDF viewing needs
-
-## 📞 Support & Resources
-
-### Getting Help
-- 📚 [**Documentation**](./intro): Complete documentation
-- 🎯 [**Live Demo**](https://angular-pdf-viewer-demo.vercel.app/): See it in action
-- 💬 [**GitHub Discussions**](https://github.com/intbot/ng2-pdfjs-viewer/discussions): Ask questions
-- 🐛 [**GitHub Issues**](https://github.com/intbot/ng2-pdfjs-viewer/issues): Report bugs
-
-### Migration Support
-- 🔧 [**Migration Guide**](./migration/overview): Step-by-step migration
-- 📚 [**Examples**](./examples/basic-usage): Practical code examples
-- 🚀 [**Getting Started**](./getting-started): Quick setup guide
-
----
-
-**Ready to upgrade?** Start with our [Migration Guide](./migration/overview) and experience the power of ng2-pdfjs-viewer v25.x!
+Template inputs replaced the HTML-string properties, several inputs were renamed for clarity, and some event payloads changed shape. The [migration guide](./migration/overview) walks through the upgrade from v20.

--- a/docs-website/docs/features/accessibility.md
+++ b/docs-website/docs/features/accessibility.md
@@ -1,6 +1,6 @@
 # Accessibility
 
-ng2-pdfjs-viewer embeds the full Mozilla PDF.js viewer — the same viewer that ships in Firefox — and inherits its accessibility architecture. This page summarizes what you get out of the box, what the component adds on top, and what remains your application's responsibility.
+ng2-pdfjs-viewer embeds the full Mozilla PDF.js viewer — the same viewer that ships in Firefox — and inherits its accessibility architecture. This page summarizes what you get by default, what the component adds on top, and what remains your application's responsibility.
 
 ## What the Viewer Provides
 

--- a/docs-website/docs/features/security.md
+++ b/docs-website/docs/features/security.md
@@ -268,7 +268,7 @@ ng2-pdfjs-viewer is fully compliant with strict Content Security Policy (`style-
 
 ### Using with Strict CSP
 
-The viewer works out-of-the-box with strict CSP policies:
+The viewer works with strict CSP policies:
 
 ```html
 <!-- Your index.html -->

--- a/docs-website/docs/features/theming.md
+++ b/docs-website/docs/features/theming.md
@@ -1,10 +1,10 @@
 # Theming & Customization
 
-Learn how to customize the appearance of ng2-pdfjs-viewer to match your application's design.
+ng2-pdfjs-viewer styles the viewer with CSS custom properties, so you can match it to your app without forking PDF.js.
 
-## Theme System Overview
+## Theme system overview
 
-ng2-pdfjs-viewer v25.x introduces a powerful theme system based on CSS custom properties, allowing complete visual customization while maintaining performance and accessibility.
+Theming runs on CSS custom properties. Pick a built-in `theme` (light, dark, or auto), override individual colors through a config object, or set the variables directly. Dark mode can re-color the page content itself, not just the toolbar.
 
 ## Basic Theming
 


### PR DESCRIPTION
Second pass of the human-voice cleanup, scoped by an audit rather than a blanket rewrite.

### changelog.md — rewritten (223 → ~40 lines)
- Removed fabricated performance benchmarks ("40% faster", "25% memory reduction", etc.) — they were never measured and shouldn't be published.
- Dropped the padding sections (Community Highlights, Acknowledgments, Support & Resources) and the marketing close, plus a stale "PDF.js v5.3.93 / Angular 20+" block that contradicted the 6.x line at the top.
- Kept the real content: latest highlights, the v25 architecture summary, and the breaking-changes / renames table. Links to the canonical `CHANGELOG.md` for per-version detail.

### Stray superlatives
- `theming.md`: "powerful theme system … complete visual customization" → a concrete description of how theming works.
- `accessibility.md`, `security.md`: dropped "out of the box".

### Deliberately left unchanged
The technical feature guides (custom-ui, annotation-editing, read-aloud, ai-assistant, forms, search, etc.) read human already — their openers are specific and they carry honest constraints. Editing prose that's fine is the churn the voice rule exists to prevent, so the audit stopped where the real tells did.