### PR TITLE
Append the file param last on the viewer URL (#305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The `file` parameter is now appended last on the viewer URL, so a hash
+  fragment carried on the PDF URL (e.g. `doc.pdf#search=foo`, `#page=2`) reaches
+  PDF.js intact instead of swallowing the viewer's own query parameters. Thanks
+  to @THCavaciuti for the report and fix. (#305)
+
 ## [26.0.2] - 2026-06-22
 
 ### Fixed

--- a/lib/src/ng2-pdfjs-viewer.component.ts
+++ b/lib/src/ng2-pdfjs-viewer.component.ts
@@ -3114,11 +3114,16 @@ export class PdfJsViewerComponent
     const base = this.viewerFolder
       ? `${this.viewerFolder}/web/viewer.html`
       : `assets/pdfjs/web/viewer.html`;
-    let viewerUrl = `${base}?file=${fileUrl}`;
+    // Control params go in the query string first; the file URL is appended
+    // LAST. A consumer's file URL may end in a hash fragment that PDF.js reads
+    // for navigation (e.g. doc.pdf#search=foo, #page=2). Anything appended
+    // after the file param would land inside that fragment instead of the
+    // query string - so file trails the whole URL, leaving the hash where
+    // PDF.js looks for it. (#305)
+    let viewerUrl = `${base}?urlValidation=${this.urlValidation === false ? 0 : 1}`;
     if (typeof this.viewerId !== "undefined") {
       viewerUrl += `&viewerId=${this.viewerId}`;
     }
-    viewerUrl += `&urlValidation=${this.urlValidation === false ? 0 : 1}`;
 
     // Init-time PDF.js options (signature editor, page colors, passthrough).
     // These are read by PDF.js during initialize() - before the postMessage
@@ -3136,6 +3141,9 @@ export class PdfJsViewerComponent
     if (isDevMode()) {
       viewerUrl += `&_t=${Date.now()}`;
     }
+
+    // File last (see above): its optional #hash fragment must trail the URL.
+    viewerUrl += `&file=${fileUrl}`;
     return viewerUrl;
   }
 

--- a/lib/tests/component-logic.spec.ts
+++ b/lib/tests/component-logic.spec.ts
@@ -69,6 +69,24 @@ describe("iframeSandbox allowlist", () => {
   });
 });
 
+describe("viewer URL parameter order (#305)", () => {
+  it("appends file last so a hash fragment in the file URL is preserved", () => {
+    const comp = makeComponent();
+    const url = (comp as any).buildViewerUrl("doc.pdf#search=foo") as string;
+    const [query, hash] = url.split("#");
+
+    // The consumer's hash trails the whole URL, untouched - PDF.js reads it.
+    expect(hash).toBe("search=foo");
+    // Control params stay in the query string (before the hash), not the
+    // fragment - so the wrapper's URLSearchParams(location.search) still sees
+    // them. file is the final query param.
+    const params = new URLSearchParams(query.slice(query.indexOf("?")));
+    expect(params.get("urlValidation")).toBe("1");
+    expect(params.get("file")).toBe("doc.pdf");
+    expect(query.endsWith("&file=doc.pdf")).toBe(true);
+  });
+});
+
 describe("init-time PDF.js options on the viewer URL", () => {
   function urlOptions(comp: PdfJsViewerComponent): Record<string, unknown> {
     const url = (comp as any).buildViewerUrl("test.pdf") as string;


### PR DESCRIPTION
## What

`buildViewerUrl` now puts the library's control parameters in the query string first and appends `file=...` **last**.

## Why

A PDF URL can carry a hash fragment that PDF.js reads for navigation — `doc.pdf#search=foo`, `#page=2`, `#zoom=150`. With `file=...` placed first, everything appended after it (`urlValidation`, `viewerId`, `pjsOptions`, the dev-mode cache-bust) landed *inside* that fragment rather than the query string. `window.location.search` stops at `#`, so the wrapper's `URLSearchParams(location.search)` never saw those params, and the consumer's hash was polluted with them.

Building the control params first and appending `file` last leaves the hash trailing the whole URL, where PDF.js looks for it, and keeps every control param in the query string.

## Notes

- Reported and originally fixed in #305 by @THCavaciuti; reimplemented here against the current `buildViewerUrl`.
- Added a regression test (`viewer URL parameter order`) asserting the hash is preserved and the control params stay in the query string. Full `vitest run` of `component-logic.spec.ts` passes (16/16).
- Pure URL-string reordering — no API change, no new dependency.