### PR TITLE
Landing: sharper hero headline; fix dead canonical/og:image URL

### DIFF
--- a/docs-website/docusaurus.config.ts
+++ b/docs-website/docusaurus.config.ts
@@ -18,8 +18,9 @@ const config: Config = {
     v4: true, // Improve compatibility with the upcoming Docusaurus v4
   },
 
-  // Set the production url of your site here
-  url: 'https://ng2-pdfjs-viewer.github.io',
+  // Set the production url of your site here (the deployed docs host).
+  // Used for canonical, og:url, og:image and the sitemap.
+  url: 'https://angular-pdf-viewer-docs.vercel.app',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',

--- a/docs-website/src/pages/index.tsx
+++ b/docs-website/src/pages/index.tsx
@@ -31,8 +31,8 @@ function Hero() {
               <span className={styles.live} /> 8.3M+ downloads · since 2018 · Angular 10–22
             </span>
             <h1 className={styles.title}>
-              The Angular PDF viewer,<br />
-              <em>finally</em> fun to explore.
+              The Angular PDF viewer you can<br />
+              <em>try</em> before you npm i.
             </h1>
             <p className={styles.sub}>
               40+ inputs, 19 events, zero runtime dependencies. Flip a control, watch the real{' '}


### PR DESCRIPTION
Two small landing-page fixes.

## Hero headline
The H1 read *"The Angular PDF viewer, finally fun to explore."* — a vibe rather than a claim, and it undercut the project's positioning. It now reads:

> The Angular PDF viewer you can **try** before you npm i.

Keeps the interactive-playground hook (the whole point of the page) but states it as a concrete promise. The strong, concrete sub-headline is unchanged.

## Dead canonical / social URL
`docusaurus.config.ts` set `url` to `https://ng2-pdfjs-viewer.github.io`, a host that 404s — the docs deploy to Vercel. As a result `canonical`, `og:url`, `og:image`, and `twitter:image` all pointed at dead URLs, so link previews showed no image and the SEO canonical was wrong.

Pointed `url` at the deployed docs host. Verified the social card and logo resolve there (`/img/ng2-pdfjs-viewer-social-card.png` → `200 image/png`).