### PR TITLE
Release 26.0.3: viewer-URL hash-fragment fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [26.0.3] - 2026-06-22
+
 ### Fixed
 - The `file` parameter is now appended last on the viewer URL, so a hash
   fragment carried on the PDF URL (e.g. `doc.pdf#search=foo`, `#page=2`) reaches

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ng2-pdfjs-viewer",
-  "version": "26.0.2",
+  "version": "26.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ng2-pdfjs-viewer",
-      "version": "26.0.2",
+      "version": "26.0.3",
       "license": "Apache-2.0 (Commons Clause)",
       "devDependencies": {
         "@angular/compiler-cli": "^22.0.0",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-pdfjs-viewer",
-  "version": "26.0.2",
+  "version": "26.0.3",
   "description": "The most comprehensive Angular PDF viewer, powered by Mozilla PDF.js 6 — view, annotate, sign, fill forms, search, and read aloud from one component. 8.3M+ downloads, mobile-first, production-ready.",
   "author": {
     "name": "Aneesh Goapalakrishnan",


### PR DESCRIPTION
Cuts **26.0.3**.

- Bumps the published package `26.0.2 → 26.0.3` (`lib/package.json` + lockfile).
- Promotes the CHANGELOG `[Unreleased]` entry — the #305 file-parameter-order fix, already merged in #342 — to a dated `26.0.3` section.

No source changes; the fix itself landed in #342. Merging this, then pushing the `v26.0.3` tag, triggers the gated publish workflow (`release` environment — requires reviewer approval).