### PR TITLE
CI: build + test lib on PRs to catch lockfile/dep breaks pre-release

### DIFF
--- a/.github/workflows/lib-ci.yml
+++ b/.github/workflows/lib-ci.yml
@@ -1,0 +1,50 @@
+name: lib CI
+
+# Builds and tests the published library on every PR (and on master) that
+# touches lib/. This mirrors the tag-driven publish workflow's `npm ci` +
+# `npm run build` on the SAME runner (ubuntu-latest, Node 24), so lockfile and
+# peer-dependency breaks — e.g. a Dependabot bump that leaves package-lock.json
+# inconsistent, or a Windows-regenerated lock missing other platforms' optional
+# binaries — fail here on the PR instead of at release time.
+on:
+  pull_request:
+    paths:
+      - 'lib/**'
+      - '.github/workflows/lib-ci.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'lib/**'
+      - '.github/workflows/lib-ci.yml'
+
+# Cancel superseded runs on the same ref to save runner minutes.
+concurrency:
+  group: lib-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+# Read-only: this job builds and tests, it never writes.
+permissions: read-all
+
+jobs:
+  build:
+    name: Build & test (lib)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          # Match the publish workflow: the Angular 22 toolchain needs Node >= 24.15.
+          node-version: '24.x'
+          cache: 'npm'
+          cache-dependency-path: lib/package-lock.json
+      # `npm ci` is the exact command the tag publish runs; running it here on
+      # Linux is what would have caught the 26.0.3 lockfile breaks on the PR.
+      - name: Install dependencies
+        working-directory: ./lib
+        run: npm ci
+      - name: Build
+        working-directory: ./lib
+        run: npm run build
+      - name: Test
+        working-directory: ./lib
+        run: npm test


### PR DESCRIPTION
## Why
The 26.0.3 release failed twice at publish time because nothing runs `npm ci` for `lib/` on PRs:
1. A Dependabot lib-dev-deps bump (#332) left `lib/package-lock.json` with an `@angular/compiler-cli` ↔ `@angular/compiler` peer mismatch (`npm ci` ERESOLVE).
2. A later lockfile regen done on Windows dropped the non-Windows optional platform binaries (`@napi-rs/nice-*`, `@parcel/watcher-*`, …), which Linux `npm ci` rejects as missing.

Both passed the existing PR checks (CodeQL + Vercel previews) and only blew up on the publish tag, on the Linux runner.

## What
Adds `.github/workflows/lib-ci.yml`: on PRs and master pushes that touch `lib/`, it runs `npm ci` → `npm run build` → `npm test` in `lib/` on **ubuntu-latest / Node 24** — the same runner and commands the tag publish uses. Either failure above would have failed this check on the PR instead of at release.

- Hash-pinned `checkout` / `setup-node` SHAs match `main.yml` (keeps OpenSSF Scorecard's pinned-deps happy).
- Path-filtered to `lib/**`, so docs-only PRs don't pay for it.
- `concurrency` cancels superseded runs; `permissions: read-all` (build/test only).

## Follow-up (your call, in repo settings)
To make this *block* merges, add **`Build & test (lib)`** as a required status check in branch protection for `master`. Without that it runs and reports but won't gate.