### PR TITLE
CI: enforce docs-voice on PRs, cover MDX, and use CHANGELOG for release notes

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,8 +1,9 @@
 #!/bin/sh
-# Keep the docs human: flag AI-generator filler in staged Markdown.
+# Keep the docs human: flag AI-generator filler in staged Markdown/MDX.
 # Enable once per clone:  git config core.hooksPath .githooks
 # Bypass once (rare):     git commit --no-verify
-if git diff --cached --name-only --diff-filter=ACM | grep -q '\.md$'; then
+# (CI enforces the same check on every PR, so a missing hook is a backstop, not a gap.)
+if git diff --cached --name-only --diff-filter=ACM | grep -qE '\.mdx?$'; then
   command -v node >/dev/null 2>&1 || { echo "pre-commit: node not found, skipping docs-voice check"; exit 0; }
   node scripts/check-docs-voice.mjs --staged || exit 1
 fi

--- a/.github/workflows/docs-voice.yml
+++ b/.github/workflows/docs-voice.yml
@@ -1,0 +1,40 @@
+name: docs voice
+
+# Enforce the human-voice writing rule on every PR: scan the Markdown/MDX the
+# PR adds AND the PR's own title + body for generator filler (the BLOCK tier in
+# scripts/check-docs-voice.mjs). This is the server-side backstop for the local
+# pre-commit hook, and the only gate that sees PR prose — which never reaches a
+# commit, so the hook can't catch it.
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+concurrency:
+  group: docs-voice-${{ github.ref }}
+  cancel-in-progress: true
+
+# Read-only, no secrets used: safe for fork PRs (this is `pull_request`, not
+# `pull_request_target`).
+permissions: read-all
+
+jobs:
+  voice:
+    name: Docs voice
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0 # need history to diff the PR against its base
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '24.x'
+      - name: Markdown/MDX added by this PR
+        run: node scripts/check-docs-voice.mjs --base=${{ github.event.pull_request.base.sha }}
+      - name: PR title and body
+        # Passed via env (not inlined into the script) so PR text can't inject shell.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          printf '%s\n\n%s\n' "$PR_TITLE" "$PR_BODY" > .pr-text.md
+          node scripts/check-docs-voice.mjs .pr-text.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,22 @@ jobs:
     permissions:
       contents: write # create the GitHub release for the pushed tag
     steps:
-      # Uses the runner's built-in GitHub CLI — no third-party action, no
-      # checkout needed (the release is created from the tag via the API).
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      # Use the hand-written CHANGELOG section for this version as the release
+      # notes (it goes through the docs-voice check, so it reads human), and
+      # fall back to auto-generated notes only if the version has no entry.
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: >
-          gh release create "${{ github.ref_name }}"
-          --repo "${{ github.repository }}"
-          --title "Release ${{ github.ref_name }}"
-          --generate-notes
+        run: |
+          ver="${GITHUB_REF_NAME#v}"
+          awk -v start="## [${ver}]" \
+            'index($0,start)==1{c=1;next} c&&index($0,"## [")==1{exit} c{print}' \
+            CHANGELOG.md > notes.md
+          if [ -s notes.md ]; then
+            gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
+              --title "Release $GITHUB_REF_NAME" --notes-file notes.md
+          else
+            gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
+              --title "Release $GITHUB_REF_NAME" --generate-notes
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,10 +97,10 @@ published `ng2-pdfjs-viewer` for Vercel builds; `yalc link` overrides it with yo
 
 ## Writing voice (README, docs-website, CHANGELOG, examples)
 
-Public prose must read like a maintainer wrote it, not a content generator. The
-`.githooks/pre-commit` hook runs `node scripts/check-docs-voice.mjs --staged` on staged Markdown
-and blocks generator filler; run it yourself before committing docs (enable the hook once per
-clone with `git config core.hooksPath .githooks`).
+Public prose must read like a maintainer wrote it, not a content generator. CI enforces this on
+every PR — `scripts/check-docs-voice.mjs` scans the Markdown/MDX a PR adds and the PR title/body.
+The `.githooks/pre-commit` hook runs the same check on staged Markdown/MDX locally; run it before
+committing docs (enable once per clone with `git config core.hooksPath .githooks`).
 
 - Lead with a specific fact, number, or behavior, not an adjective. Cut filler superlatives
   (`seamless`, `effortless`, `blazing-fast`, `cutting-edge`, `world-class`). `comprehensive`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,14 +208,16 @@ ng2-pdfjs-viewer/
 
 ### Writing voice
 
-Docs and README copy should read like a maintainer wrote them, not a content generator. A
-pre-commit hook enforces this — enable it once per clone:
+Docs and README copy should read like a maintainer wrote them, not a content generator. CI
+enforces this on every PR: `check-docs-voice.mjs` scans the Markdown/MDX a PR adds and the PR's
+own title and body, and blocks generator filler. A pre-commit hook runs the same check locally so
+you catch it before pushing — enable it once per clone:
 
 ```bash
 git config core.hooksPath .githooks
 ```
 
-It runs `node scripts/check-docs-voice.mjs --staged` and blocks generator filler. The rules:
+It runs `node scripts/check-docs-voice.mjs --staged` on staged Markdown/MDX. The rules:
 
 - Lead with a concrete fact, number, or behavior, not an adjective.
 - Cut filler superlatives (`seamless`, `effortless`, `blazing-fast`, `cutting-edge`, `world-class`).

--- a/scripts/check-docs-voice.mjs
+++ b/scripts/check-docs-voice.mjs
@@ -2,8 +2,9 @@
 // check-docs-voice.mjs — flags "reads as AI-generated" tells in Markdown.
 //
 // Usage:
-//   node scripts/check-docs-voice.mjs --staged        # scan added lines of staged *.md (pre-commit)
-//   node scripts/check-docs-voice.mjs <file.md> ...    # scan whole files (manual / leak-guard)
+//   node scripts/check-docs-voice.mjs --staged         # added lines of staged *.md/*.mdx (pre-commit)
+//   node scripts/check-docs-voice.mjs --base=<ref>     # added lines of *.md/*.mdx vs <ref> (CI on a PR)
+//   node scripts/check-docs-voice.mjs <file> ...       # whole files (PR body temp file / manual)
 //
 // Two tiers:
 //   BLOCK — hype/filler with ~no place in honest docs. Exit 1 (fails the commit).
@@ -50,13 +51,9 @@ const WARN = [
 
 const EMDASH_WARN = 4; // per file's scanned content
 
-function stagedAddedLines() {
-  let out = '';
-  try {
-    out = execSync('git diff --cached --unified=0 --no-color -- "*.md"', { encoding: 'utf8' });
-  } catch {
-    return [];
-  }
+// Parse `git diff --unified=0` output into { file, line, text } rows for each
+// ADDED line, so we only flag what a change introduces, not pre-existing prose.
+function parseAddedLines(out) {
   const rows = [];
   let file = null;
   let newLine = 0;
@@ -70,6 +67,18 @@ function stagedAddedLines() {
   return rows;
 }
 
+// Added Markdown/MDX lines for a `git diff` selector: '--cached' for the
+// pre-commit hook, '<base>...HEAD' for CI against the PR base.
+function addedLines(selector) {
+  let out = '';
+  try {
+    out = execSync(`git diff ${selector} --unified=0 --no-color -- "*.md" "*.mdx"`, { encoding: 'utf8' });
+  } catch {
+    return [];
+  }
+  return parseAddedLines(out);
+}
+
 function wholeFileLines(files) {
   const rows = [];
   for (const f of files) {
@@ -81,9 +90,15 @@ function wholeFileLines(files) {
 }
 
 const args = process.argv.slice(2);
-const rows = args.includes('--staged')
-  ? stagedAddedLines()
-  : wholeFileLines(args.filter((a) => !a.startsWith('--')));
+const baseArg = args.find((a) => a.startsWith('--base='));
+let rows;
+if (args.includes('--staged')) {
+  rows = addedLines('--cached');                                   // pre-commit hook
+} else if (baseArg) {
+  rows = addedLines(`${baseArg.slice('--base='.length)}...HEAD`);  // CI: added lines vs PR base
+} else {
+  rows = wholeFileLines(args.filter((a) => !a.startsWith('--')));  // whole files (PR body, manual)
+}
 
 const blocks = [];
 const warns = [];


### PR DESCRIPTION
Closes the coverage gaps in the human-voice guard: until now it was a local, Markdown-only, opt-in pre-commit hook, so it didn't cover other contributors, PR prose, MDX, or release notes.

## Changes
- **New `docs-voice.yml`** — runs `check-docs-voice.mjs` on every PR (the BLOCK tier) against two surfaces: the Markdown/MDX the PR adds (diff vs base) and the PR's own title + body. Server-side, so it applies to everyone regardless of local hook setup, and it's the only gate that sees PR text.
- **Checker** — added a `--base=<ref>` mode (added lines vs a ref, for CI) and folded `*.mdx` in next to `*.md`.
- **Pre-commit hook** — matches `*.mdx` too, so the local pre-check mirrors CI.
- **`release.yml`** — the GitHub release now uses the hand-written CHANGELOG section for the tagged version as its notes (that section already passes docs-voice), falling back to auto-generated notes only if the version has no entry.
- Documented the CI enforcement in `CONTRIBUTING.md` and `CLAUDE.md`.

## Coverage after this
| Surface | Before | After |
|---|---|---|
| Root + docs-site Markdown | local hook only | CI-enforced |
| Docs-site MDX | not scanned | CI-enforced |
| PR title + body | not scanned | CI-enforced |
| Release notes | auto-generated | from CHANGELOG (voice-checked) |

## Still not machine-checkable (by design)
Issue comments (never touch git) and non-Markdown UI copy (`.tsx`/`.html`, e.g. the docs landing hero) rely on the `CLAUDE.md` rule plus review. The checker also flags keyword filler, not all taste issues — it would catch `blazing-fast`, not a cutesy tagline.

This PR's own title and body are checked by the new workflow it adds.