### PR TITLE
CI: run lib build on every PR; reframe docs check as house style

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,9 +1,9 @@
 #!/bin/sh
-# Keep the docs human: flag AI-generator filler in staged Markdown/MDX.
+# Flag filler and marketing-speak in staged Markdown/MDX (house style).
 # Enable once per clone:  git config core.hooksPath .githooks
 # Bypass once (rare):     git commit --no-verify
 # (CI enforces the same check on every PR, so a missing hook is a backstop, not a gap.)
 if git diff --cached --name-only --diff-filter=ACM | grep -qE '\.mdx?$'; then
-  command -v node >/dev/null 2>&1 || { echo "pre-commit: node not found, skipping docs-voice check"; exit 0; }
+  command -v node >/dev/null 2>&1 || { echo "pre-commit: node not found, skipping docs-style check"; exit 0; }
   node scripts/check-docs-voice.mjs --staged || exit 1
 fi

--- a/.github/workflows/docs-voice.yml
+++ b/.github/workflows/docs-voice.yml
@@ -1,16 +1,16 @@
-name: docs voice
+name: docs style
 
-# Enforce the human-voice writing rule on every PR: scan the Markdown/MDX the
-# PR adds AND the PR's own title + body for generator filler (the BLOCK tier in
-# scripts/check-docs-voice.mjs). This is the server-side backstop for the local
-# pre-commit hook, and the only gate that sees PR prose — which never reaches a
-# commit, so the hook can't catch it.
+# Enforce the house writing style on every PR: scan the Markdown/MDX the PR adds
+# AND the PR's own title + body for filler and marketing-speak (the BLOCK tier
+# in scripts/check-docs-voice.mjs). This is the server-side backstop for the
+# local pre-commit hook, and the only gate that sees PR prose — which never
+# reaches a commit, so the hook can't catch it.
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
 concurrency:
-  group: docs-voice-${{ github.ref }}
+  group: docs-style-${{ github.ref }}
   cancel-in-progress: true
 
 # Read-only, no secrets used: safe for fork PRs (this is `pull_request`, not
@@ -18,8 +18,8 @@ concurrency:
 permissions: read-all
 
 jobs:
-  voice:
-    name: Docs voice
+  style:
+    name: Docs style
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/lib-ci.yml
+++ b/.github/workflows/lib-ci.yml
@@ -1,21 +1,18 @@
 name: lib CI
 
-# Builds and tests the published library on every PR (and on master) that
-# touches lib/. This mirrors the tag-driven publish workflow's `npm ci` +
-# `npm run build` on the SAME runner (ubuntu-latest, Node 24), so lockfile and
-# peer-dependency breaks — e.g. a Dependabot bump that leaves package-lock.json
-# inconsistent, or a Windows-regenerated lock missing other platforms' optional
-# binaries — fail here on the PR instead of at release time.
+# Builds and tests the published library on every PR. This mirrors the
+# tag-driven publish workflow's `npm ci` + `npm run build` on the SAME runner
+# (ubuntu-latest, Node 24), so lockfile and peer-dependency breaks — e.g. a
+# Dependabot bump that leaves package-lock.json inconsistent, or a
+# Windows-regenerated lock missing other platforms' optional binaries — fail
+# here on the PR instead of at release time.
 on:
+  # Not path-filtered: a required status check that gets skipped by a path
+  # filter leaves the PR stuck waiting on it, so this runs on every PR. npm
+  # caching keeps the docs-only case cheap.
   pull_request:
-    paths:
-      - 'lib/**'
-      - '.github/workflows/lib-ci.yml'
   push:
     branches: [master]
-    paths:
-      - 'lib/**'
-      - '.github/workflows/lib-ci.yml'
 
 # Cancel superseded runs on the same ref to save runner minutes.
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       # Use the hand-written CHANGELOG section for this version as the release
-      # notes (it goes through the docs-voice check, so it reads human), and
-      # fall back to auto-generated notes only if the version has no entry.
+      # notes (it passes the docs-style check), falling back to auto-generated
+      # notes only if the version has no entry.
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,10 +95,10 @@ published `ng2-pdfjs-viewer` for Vercel builds; `yalc link` overrides it with yo
   additive, backward-compatible changes and document breaking ones in `CHANGELOG.md` / an
   upgrade guide.
 
-## Writing voice (README, docs-website, CHANGELOG, examples)
+## Writing style (README, docs-website, CHANGELOG, examples)
 
-Public prose must read like a maintainer wrote it, not a content generator. CI enforces this on
-every PR — `scripts/check-docs-voice.mjs` scans the Markdown/MDX a PR adds and the PR title/body.
+Public prose should read like a maintainer wrote it — concrete, specific, and varied. CI enforces
+this house style on every PR: `scripts/check-docs-voice.mjs` scans the Markdown/MDX a PR adds and the PR title/body.
 The `.githooks/pre-commit` hook runs the same check on staged Markdown/MDX locally; run it before
 committing docs (enable once per clone with `git config core.hooksPath .githooks`).
 
@@ -107,7 +107,7 @@ committing docs (enable once per clone with `git config core.hooksPath .githooks
   `feature-rich`, `AI-enabled`, and `mobile-first` are deliberate positioning — keep those.
 - Keep a real voice: first person where it fits, name trade-offs, state honest limits and constraints.
 - Vary sentence length and shape. Several sections in an identical title-then-one-sentence pattern
-  is the machine's fingerprint; break it up.
+  read as monotonous; break it up.
 - Don't open with `Welcome to the comprehensive documentation`, `In this guide we'll`, or
   `Let's dive in`. Keep code examples and concrete constraints; they are what earn a reader's trust.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,11 +206,11 @@ ng2-pdfjs-viewer/
 - Document all public methods
 - Include type information
 
-### Writing voice
+### Writing style
 
-Docs and README copy should read like a maintainer wrote them, not a content generator. CI
-enforces this on every PR: `check-docs-voice.mjs` scans the Markdown/MDX a PR adds and the PR's
-own title and body, and blocks generator filler. A pre-commit hook runs the same check locally so
+Docs and README copy should read like a maintainer wrote them — concrete and specific. CI
+enforces a house style on every PR: `check-docs-voice.mjs` scans the Markdown/MDX a PR adds and the
+PR's own title and body, and blocks filler and marketing-speak. A pre-commit hook runs the same check locally so
 you catch it before pushing — enable it once per clone:
 
 ```bash

--- a/scripts/check-docs-voice.mjs
+++ b/scripts/check-docs-voice.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// check-docs-voice.mjs — flags "reads as AI-generated" tells in Markdown.
+// check-docs-voice.mjs — flags filler and marketing-speak in Markdown/MDX prose.
 //
 // Usage:
 //   node scripts/check-docs-voice.mjs --staged         # added lines of staged *.md/*.mdx (pre-commit)
@@ -11,8 +11,8 @@
 //   WARN  — softer or brand-adjacent tells. Printed, never blocks.
 //
 // Brand language is intentional and NOT flagged: "comprehensive", "feature-rich",
-// "AI-enabled", "mobile-first", "#1". Keep those. The point is to kill generator
-// filler, not our positioning. Tune the lists below as the docs evolve.
+// "AI-enabled", "mobile-first", "#1". Keep those. The point is to cut filler and
+// marketing-speak, not our positioning. Tune the lists below as the docs evolve.
 import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
@@ -118,18 +118,18 @@ for (const { file, line, text } of rows) {
 }
 
 const fmt = (f) => `  ${f.file}:${f.line}  ${f.label}\n      ${f.text.slice(0, 100)}`;
-if (!rows.length) { console.log('docs-voice: nothing to scan.'); process.exit(0); }
+if (!rows.length) { console.log('docs-style: nothing to scan.'); process.exit(0); }
 
 if (warns.length || [...emdash.values()].some((n) => n >= EMDASH_WARN)) {
-  console.log('\n⚠ docs-voice WARN (review, not blocking):');
+  console.log('\n⚠ docs-style WARN (review, not blocking):');
   warns.forEach((w) => console.log(fmt(w)));
   for (const [f, n] of emdash) if (n >= EMDASH_WARN) console.log(`  ${f}  em-dash density: ${n} — prefer periods/commas`);
 }
 if (blocks.length) {
-  console.log('\n✗ docs-voice BLOCK (generator filler — rewrite before committing):');
+  console.log('\n✗ docs-style BLOCK (filler — rewrite before committing):');
   blocks.forEach((b) => console.log(fmt(b)));
   console.log('\nSee the writing rule in CONTRIBUTING.md / CLAUDE.md. Bypass once with `git commit --no-verify`.\n');
   process.exit(1);
 }
-console.log(`docs-voice: clean${warns.length ? ' (warnings above)' : ''}.`);
+console.log(`docs-style: clean${warns.length ? ' (warnings above)' : ''}.`);
 process.exit(0);


### PR DESCRIPTION
Two changes, both prep for turning these into required status checks.

## 1. `Build & test (lib)` runs on every PR
Dropped the `lib/**` path filter on `lib-ci.yml`. A required status check that gets skipped by a path filter leaves the PR stuck waiting on it, so to make this one required it has to run on every PR. npm caching keeps the docs-only case cheap.

## 2. Docs check reframed as house style
The prose linter is now presented as a neutral house-style check rather than an "is-this-AI-generated" one:
- The PR check is renamed **Docs voice → Docs style** (job/workflow name + script output labels).
- The `content generator` / `AI-generated` wording is dropped from `CLAUDE.md`, `CONTRIBUTING.md`, the workflow, the hook, and the script header.
- The rules, wordlist, and mechanism are unchanged — same BLOCK/WARN behavior.

No functional change to what's flagged; this is naming and framing only, plus the path-filter drop.