### PR TITLE
Demo: bump playground to ng2-pdfjs-viewer 26.0.3

### DIFF
--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -13271,9 +13271,9 @@
       }
     },
     "node_modules/ng2-pdfjs-viewer": {
-      "version": "26.0.2",
-      "resolved": "https://registry.npmjs.org/ng2-pdfjs-viewer/-/ng2-pdfjs-viewer-26.0.2.tgz",
-      "integrity": "sha512-4nER40Asy2HOjSM5eM/6jKURG/o9TEEU1JaXMa1rTDe85SxvnJ6Zp5GeCClVz8Q4PvKdReC64vlj0uVnpCuQKw==",
+      "version": "26.0.3",
+      "resolved": "https://registry.npmjs.org/ng2-pdfjs-viewer/-/ng2-pdfjs-viewer-26.0.3.tgz",
+      "integrity": "sha512-MogRkfHcSP63CTfo48HIZHgSOZb8GhTg2HA5g2IdXTj7+bBsBMftbpVenap/a7lesv9PeqnUfPq/JCdKK4IcYA==",
       "license": "Apache-2.0 + Commons Clause",
       "dependencies": {
         "tslib": "^2.3.0"


### PR DESCRIPTION
Pins the playground (the deployed demo) to the current release, 26.0.3.

- Surgical lockfile edit: `version` + `resolved` + `integrity` for the published 26.0.3 only. `package.json` stays at `^26.0.0` (already satisfied).
- The lock is edited in place, **not** regenerated, to keep the cross-platform optional binaries intact (a Windows regen drops the non-Windows ones — the trap that broke the 26.0.3 release twice).
- The demo's Vercel preview runs `npm ci` on Linux, so it validates this lock end to end.