### PR TITLE
Add a chromeless input for embedded, toolbar-less viewing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [26.1.0] - 2026-06-22
+
+### Added
+- `chromeless` input: a single switch that hides the toolbar and sidebar so the
+  viewer shows just the scrolling pages — an embedded/inline preview mode. It is
+  shorthand for `showToolbar=false` + `showSidebar=false` and overrides them
+  without mutating those bindings, so toggling it off restores them. Reach for
+  `pageOverlayTpl` when you need per-page DOM in the host app.
+
 ## [26.0.3] - 2026-06-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -139,6 +139,18 @@ ai = { endpoint: "https://api.openai.com/v1/chat/completions", apiKey: "…", mo
 </ng-template>
 ```
 
+**Embed just the pages (chromeless)**
+
+```html
+<ng2-pdfjs-viewer pdfSrc="assets/doc.pdf" [chromeless]="true"></ng2-pdfjs-viewer>
+```
+
+One switch hides the toolbar and sidebar so the iframe shows only the scrolling
+pages — handy for inline previews. It's shorthand for `[showToolbar]="false"` +
+`[showSidebar]="false"` and overrides them without touching those bindings, so
+flip it off and your toolbar comes back. (There's still an iframe; reach for
+`pageOverlayTpl` when you need per-page host DOM.)
+
 ## 📚 Documentation
 
 The README is the front door — the deep reference lives on the docs site and stays in sync with each release.

--- a/docs-website/docs/api/component-inputs.md
+++ b/docs-website/docs/api/component-inputs.md
@@ -274,6 +274,26 @@ errorMessage = 'Failed to load document. Please try again.';
 
 ## Display Configuration
 
+#### `chromeless`
+- **Type**: `boolean`
+- **Default**: `false`
+- **Description**: Hide the toolbar and sidebar together so the iframe shows only
+  the scrolling pages — an embedded/inline preview mode. Shorthand for
+  `showToolbar=false` + `showSidebar=false`; it overrides both without mutating
+  those bindings, so setting it back to `false` restores whatever they were. The
+  pages still render inside an iframe with its own scroll container; use
+  [`pageOverlayTpl`](#pageoverlaytpl) when you need per-page DOM in the host app.
+
+```html
+<ng2-pdfjs-viewer pdfSrc="assets/doc.pdf" [chromeless]="true"></ng2-pdfjs-viewer>
+```
+
+#### `showToolbar`
+- **Type**: `boolean`
+- **Default**: `true`
+- **Description**: Show/hide the entire viewer toolbar. Pair with
+  `customToolbarTpl` to render your own toolbar above the iframe.
+
 ### Toolbar Controls
 
 

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ng2-pdfjs-viewer",
-  "version": "26.0.3",
+  "version": "26.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ng2-pdfjs-viewer",
-      "version": "26.0.3",
+      "version": "26.1.0",
       "license": "Apache-2.0 (Commons Clause)",
       "devDependencies": {
         "@angular/compiler-cli": "^22.0.0",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-pdfjs-viewer",
-  "version": "26.0.3",
+  "version": "26.1.0",
   "description": "The most comprehensive Angular PDF viewer, powered by Mozilla PDF.js 6 — view, annotate, sign, fill forms, search, and read aloud from one component. 8.3M+ downloads, mobile-first, production-ready.",
   "author": {
     "name": "Aneesh Goapalakrishnan",

--- a/lib/src/ng2-pdfjs-viewer.component.ts
+++ b/lib/src/ng2-pdfjs-viewer.component.ts
@@ -132,8 +132,10 @@ const PROPERTY_REGISTRY: ReadonlyArray<PropertyRegistration> = [
   { prop: "showToolbarMiddle", action: "show-toolbar-middle", level: 3, init: "always" },
   { prop: "showToolbarRight", action: "show-toolbar-right", level: 3, init: "always" },
   { prop: "showSecondaryToolbarToggle", action: "show-secondary-toolbar-toggle", level: 3, init: "always" },
-  { prop: "showToolbar", action: "show-toolbar", level: 3, init: "always" },
-  { prop: "showSidebar", action: "show-sidebar", level: 3, init: "always" },
+  // chromeless forces both hidden while leaving the consumer's own
+  // showToolbar/showSidebar bindings untouched (see the chromeless @Input).
+  { prop: "showToolbar", action: "show-toolbar", level: 3, init: "always", get: (c) => c.showToolbar && !c.chromeless },
+  { prop: "showSidebar", action: "show-sidebar", level: 3, init: "always", get: (c) => c.showSidebar && !c.chromeless },
   { prop: "showSidebarLeft", action: "show-sidebar-left", level: 3, init: "always" },
   { prop: "showSidebarRight", action: "show-sidebar-right", level: 3, init: "always" },
 
@@ -306,6 +308,9 @@ const CONFIG_FANOUT: Record<string, ReadonlyArray<string>> = {
   viewerConfig: ["useOnlyCssZoom", "externalLinkTarget", "rememberLastView"],
   autoActions: ["rotateCW", "rotateCCW"],
   errorHandling: [],
+  // chromeless is a preset, not a config object, but it reuses the fanout so a
+  // runtime toggle re-dispatches the (get-overridden) toolbar/sidebar actions.
+  chromeless: ["showToolbar", "showSidebar"],
 };
 
 function hasObservers(emitter: EventEmitter<any>): boolean {
@@ -921,6 +926,13 @@ export class PdfJsViewerComponent
   // Show/hide the entire viewer toolbar (pair with customToolbarTpl to ship a
   // fully custom host-side toolbar)
   @Input() public showToolbar: boolean = true;
+
+  // Chromeless / embedded mode: hide the toolbar and sidebar in one switch so
+  // the iframe shows just the scrolling pages. Shorthand for showToolbar=false
+  // + showSidebar=false; it overrides them without mutating those bindings, so
+  // flipping it back restores whatever they were. There is still an iframe and
+  // its own scroll container - use pageOverlayTpl if you need per-page host DOM.
+  @Input() public chromeless: boolean = false;
 
   // Host-side replacement toolbar rendered ABOVE the viewer iframe. Template
   // context: let-viewer (the component instance) for driving the public API,

--- a/lib/tests/component-logic.spec.ts
+++ b/lib/tests/component-logic.spec.ts
@@ -189,6 +189,45 @@ describe("viewerConfig fan-out", () => {
   });
 });
 
+describe("chromeless preset", () => {
+  // Run the real init snapshot and collect the steps of every batched
+  // 'configure' message, so we assert the toolbar/sidebar payloads the
+  // registry's get-overrides actually emit.
+  function configureSteps(comp: PdfJsViewerComponent): any[] {
+    const steps: any[] = [];
+    vi.spyOn(comp as any, "dispatchAction").mockImplementation(
+      (action: string, payload: any) => {
+        if (action === "configure") steps.push(...payload);
+        return Promise.resolve();
+      },
+    );
+    (comp as any).queueAllConfigurations();
+    return steps;
+  }
+  const payloadOf = (steps: any[], action: string) =>
+    steps.find((s) => s.action === action)?.payload;
+
+  it("forces toolbar and sidebar hidden when chromeless is on", () => {
+    const comp = makeComponent();
+    comp.chromeless = true;
+    const steps = configureSteps(comp);
+    expect(payloadOf(steps, "show-toolbar")).toBe(false);
+    expect(payloadOf(steps, "show-sidebar")).toBe(false);
+  });
+
+  it("leaves them visible by default", () => {
+    const steps = configureSteps(makeComponent());
+    expect(payloadOf(steps, "show-toolbar")).toBe(true);
+    expect(payloadOf(steps, "show-sidebar")).toBe(true);
+  });
+
+  it("still honors an explicit showToolbar=false on its own", () => {
+    const comp = makeComponent();
+    comp.showToolbar = false; // chromeless off: the && must keep this hiding
+    expect(payloadOf(configureSteps(comp), "show-toolbar")).toBe(false);
+  });
+});
+
 describe("wrapper event names map to component outputs", () => {
   // The component resolves emitters by reflection ("on" + eventName), so a
   // wrapper-side event whose name has no matching @Output silently drops.


### PR DESCRIPTION
`chromeless` hides the toolbar and sidebar together so the iframe shows only the scrolling pages — an embedded/inline preview mode. It answers the recurring "can I use it without the surrounding viewer chrome?" question with one switch.

It's shorthand for `showToolbar=false` + `showSidebar=false`. Rather than mutate those inputs, it overrides them through the property registry's `get` hook (`showToolbar && !chromeless`), so toggling `chromeless` back off restores whatever the consumer had set. A runtime toggle reuses the existing config fan-out to re-dispatch both actions. The pages still render inside an iframe with its own scroll container; `pageOverlayTpl` stays the path for per-page host DOM.

**Changes**
- New `@Input() chromeless` (default `false`)
- Docs: README example, API input reference, CHANGELOG entry
- Tests: 3 cases asserting the init snapshot emits `show-toolbar`/`show-sidebar` correctly with the preset on, off, and composed with an explicit `showToolbar=false`
- Bumps the library to 26.1.0 (additive, backward-compatible)

The playground demo page lands in a follow-up once 26.1.0 is on npm — the playground builds against the published package, so binding `[chromeless]` there needs the release first.