### PR TITLE
Demo: chromeless toggle on the Toolbar page + playground 26.1.0

### DIFF
--- a/docs-website/docs/features/custom-ui.md
+++ b/docs-website/docs/features/custom-ui.md
@@ -16,6 +16,22 @@ These hooks render in embedded mode only — they are not available when the vie
 with `[externalWindow]="true"`.
 :::
 
+## Embedded (chromeless) mode
+
+Sometimes you don't want to replace the chrome, just remove it. Set `[chromeless]="true"`
+to hide the toolbar and sidebar together so the iframe shows only the scrolling pages —
+handy for inline previews and thumbnails where the controls would get in the way.
+
+```html
+<ng2-pdfjs-viewer pdfSrc="assets/doc.pdf" [chromeless]="true"></ng2-pdfjs-viewer>
+```
+
+It's shorthand for `[showToolbar]="false"` + `[showSidebar]="false"`, and it overrides
+those inputs without overwriting them: bind it to a signal, flip it off, and the
+individual switches return to whatever you had set. The pages still render inside an
+iframe with its own scroll container — when you need host-app DOM on top of each page,
+reach for [`pageOverlayTpl`](#page-overlays) instead.
+
 ## Custom Toolbar
 
 `[customToolbarTpl]` renders your template in a bar above the viewer iframe. The template

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -13271,9 +13271,9 @@
       }
     },
     "node_modules/ng2-pdfjs-viewer": {
-      "version": "26.0.3",
-      "resolved": "https://registry.npmjs.org/ng2-pdfjs-viewer/-/ng2-pdfjs-viewer-26.0.3.tgz",
-      "integrity": "sha512-MogRkfHcSP63CTfo48HIZHgSOZb8GhTg2HA5g2IdXTj7+bBsBMftbpVenap/a7lesv9PeqnUfPq/JCdKK4IcYA==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/ng2-pdfjs-viewer/-/ng2-pdfjs-viewer-26.1.0.tgz",
+      "integrity": "sha512-P8sJquXnQxMkt72YZCo8PYqlECnXe7iukkZFxvVTYEiZmG+BsytqXCmIKYL7GrSh5mmGdKMKMoBLNmvBm70kow==",
       "license": "Apache-2.0 + Commons Clause",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/playground/src/app/core/feature-registry.ts
+++ b/playground/src/app/core/feature-registry.ts
@@ -28,8 +28,8 @@ export const FEATURES: FeaturePage[] = [
   // ── Viewer UI ──────────────────────────────────────────────────────
   {
     id: 'toolbar', route: 'toolbar', title: 'Toolbar & Controls', group: 'Viewer UI', icon: '▦',
-    description: 'Toggle individual buttons and whole toolbar/sidebar groups.',
-    tags: ['showDownload', 'showPrint', 'showFind', 'showFullScreen', 'showSidebar', 'showToolbarLeft'],
+    description: 'Toggle individual buttons and whole toolbar/sidebar groups, or go chromeless for an embedded pages-only view.',
+    tags: ['chromeless', 'embedded', 'showDownload', 'showPrint', 'showFind', 'showFullScreen', 'showSidebar', 'showToolbarLeft'],
     load: () => import('../pages/toolbar/toolbar.component').then((m) => m.ToolbarComponent),
   },
   {

--- a/playground/src/app/pages/toolbar/toolbar.component.html
+++ b/playground/src/app/pages/toolbar/toolbar.component.html
@@ -1,7 +1,7 @@
 <pg-page
   title="Toolbar & Controls"
-  lead="Show or hide individual toolbar buttons — or whole toolbar and sidebar groups. Flip a switch and the toolbar, and the generated code, update instantly."
-  [tags]="['showDownload','showPrint','showFind','showAnnotations','showToolbarLeft','showSecondaryToolbarToggle','showSidebar']"
+  lead="Show or hide individual toolbar buttons — or whole toolbar and sidebar groups. Or flip chromeless to hide both at once for an embedded, pages-only view. Every switch updates the viewer and the generated code instantly."
+  [tags]="['chromeless','showDownload','showPrint','showFind','showAnnotations','showToolbarLeft','showSecondaryToolbarToggle','showSidebar']"
   [code]="code()"
   docHref="https://github.com/intbot/ng2-pdfjs-viewer#readme">
 
@@ -9,6 +9,7 @@
     <ng2-pdfjs-viewer
       [pdfSrc]="src()"
       [theme]="theme.mode()"
+      [chromeless]="chromeless()"
       [showOpenFile]="showOpenFile()"
       [showDownload]="showDownload()"
       [showPrint]="showPrint()"
@@ -25,6 +26,20 @@
   </div>
 
   <div controls>
+    <div class="ph">Preset</div>
+    <div class="row">
+      <span>Chromeless <small style="opacity:.6">(hide toolbar + sidebar)</small></span>
+      <span class="switch" [class.on]="chromeless()" (click)="chromeless.set(!chromeless())"
+            role="switch" [attr.aria-checked]="chromeless()" tabindex="0"
+            (keydown.enter)="chromeless.set(!chromeless())" (keydown.space)="chromeless.set(!chromeless())"></span>
+    </div>
+    @if (chromeless()) {
+      <p style="margin:.25rem 0 0; font-size:.8rem; opacity:.65">
+        Embedded mode: just the scrolling pages. The button and group switches below
+        are overridden while this is on.
+      </p>
+    }
+
     <div class="ph">Buttons</div>
     @for (t of toggles; track t.key) {
       <div class="row">

--- a/playground/src/app/pages/toolbar/toolbar.component.ts
+++ b/playground/src/app/pages/toolbar/toolbar.component.ts
@@ -34,6 +34,10 @@ export class ToolbarComponent {
   readonly showSecondaryToolbarToggle = signal(true);
   readonly showSidebar = signal(true);
 
+  // Preset: hides toolbar + sidebar together (embedded / pages-only view).
+  // When on, it overrides the individual toggles above without changing them.
+  readonly chromeless = signal(false);
+
   readonly toggles: Toggle[] = [
     { key: 'showOpenFile', sig: this.showOpenFile, label: 'Open file' },
     { key: 'showDownload', sig: this.showDownload, label: 'Download' },
@@ -54,6 +58,8 @@ export class ToolbarComponent {
 
   readonly code = computed(() => {
     const b: CodeBinding[] = [{ name: 'pdfSrc', value: 'pdfSrc', kind: 'expr' }];
+    // chromeless is the headline preset — show it first, only when enabled
+    b.push({ name: 'chromeless', value: this.chromeless(), kind: 'boolean', omitWhen: false });
     for (const t of this.toggles) {
       // every visibility toggle defaults to true — omit at default
       b.push({ name: t.key, value: t.sig(), kind: 'boolean', omitWhen: true });


### PR DESCRIPTION
Follow-up to #351 (now published as 26.1.0). Adds a live demo for the new `chromeless` preset and updates the docs.

**Playground**
- Toolbar & Controls page gets a "Chromeless" switch under a new **Preset** section. Flipping it on hides the toolbar and sidebar together (embedded, pages-only view) and shows a hint that the individual button/group switches are overridden while it's on. The generated code includes `[chromeless]="true"` only when enabled.
- Surfaced in the page's tags and ⌘K search (`chromeless`, `embedded`).
- Bumps the playground's `ng2-pdfjs-viewer` pin to 26.1.0 (surgical lockfile edit — the lib entry only).

**Docs**
- `custom-ui.md` gains a short "Embedded (chromeless) mode" section alongside the custom-toolbar/sidebar hooks. (The API reference entry shipped with #351.)

Local Node here is v20, below the Angular CLI minimum, so the build/visual check runs on the Vercel preview (Node 24) rather than locally.