### PR TITLE
Docs: surface chromeless in the README highlights and features overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ That's the whole integration. [Wire up the assets](#-quick-start) and you have a
 | 🤖 **AI assistant (BYO)** | Point it at any OpenAI-compatible endpoint (OpenAI, Azure, Ollama, vLLM…). Answers cite pages and click through. **The library never calls an AI service on its own.** |
 | 🔊 **Read aloud** | Browser speech synthesis reads sentence by sentence, highlighting the spoken text and reporting progress. |
 | 🗂️ **Organize pages** | Reorder, delete, cut/copy/paste, extract, and merge pages in the viewer's "Manage pages" panel. |
-| 🎨 **Make it yours** | CSS-variable theming, true dark-mode page rendering, and your own Angular templates for the toolbar, sidebar, and per-page overlays. |
+| 🎨 **Make it yours** | CSS-variable theming, true dark-mode page rendering, and your own Angular templates for the toolbar, sidebar, and per-page overlays — or go `chromeless` to hide the chrome for an embedded, pages-only view. |
 | 🛡️ **Protect content** | Block print/download, disable selection, and stamp watermarks (honest client-side deterrence — not DRM). |
 | ♿ **Accessible** | Screen-reader friendly, tagged-PDF aware, keyboard navigable — with a [WCAG / EAA guide](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/ACCESSIBILITY.md). |
 

--- a/docs-website/docs/features/overview.md
+++ b/docs-website/docs/features/overview.md
@@ -14,7 +14,7 @@ PDF.js 6.x is bundled, and the component is built and tested on Angular 22 (peer
 | **Page organization** | Reorder, delete, extract, and merge pages in the viewer (opt-in). | [Page organization](./page-organization) |
 | **AI assistant (your endpoint)** | Chat panel with clickable page citations against your OpenAI-compatible endpoint. The library makes no vendor calls of its own. | [AI assistant](./ai-assistant) |
 | **Read aloud** | Sentence-by-sentence text-to-speech with in-page highlighting. | [Read aloud](./read-aloud) |
-| **Custom toolbar, sidebar & overlays** | Replace the viewer chrome with your Angular templates; project templates onto every page. | [Custom UI](./custom-ui) |
+| **Custom toolbar, sidebar & overlays** | Replace the viewer chrome with your Angular templates, project templates onto every page, or drop the chrome entirely with `chromeless` for an embedded pages-only view. | [Custom UI](./custom-ui) |
 | **Content protection** | Block print, download, and text selection; stamp watermarks. Client-side deterrence, not DRM. | [Content protection](./content-protection) |
 | **Authenticated loading** | `httpHeaders`/`withCredentials`, download progress, password-prompt events. | [Loading documents](./loading-documents) |
 | **Localization** | Locale detection, RTL, and overridable UI strings via `locale`. | [Component inputs](../api/component-inputs) |


### PR DESCRIPTION
Small follow-up to #351/#352. The `chromeless` preset already had a README code example, an API reference entry, and a section in the custom-ui guide — but the two feature *lists* (README Highlights, docs Features Overview table) only said "embedded" generically. This names `chromeless` in both so the feature is discoverable from the feature tables.

Docs-only.