### PR TITLE
Demo: add a chromeless toggle to the Quick Start & Embed page

### DIFF
--- a/playground/src/app/pages/quickstart/quickstart.component.html
+++ b/playground/src/app/pages/quickstart/quickstart.component.html
@@ -1,15 +1,22 @@
 <pg-page
   title="Quick Start & Embed"
-  lead="Add the module, drop in one element, point it at a PDF. The viewer fills its container, so sizing is just CSS — embed it full-page or inline within your content."
-  [tags]="['pdfSrc','viewerId','container sizing']"
+  lead="Add the module, drop in one element, point it at a PDF. The viewer fills its container, so sizing is just CSS — embed it full-page or inline within your content. Flip chromeless for a toolbar-less, pages-only inline preview."
+  [tags]="['pdfSrc','viewerId','container sizing','chromeless']"
   [code]="code()"
   docHref="https://github.com/intbot/ng2-pdfjs-viewer#installation">
 
   <div preview>
-    <ng2-pdfjs-viewer [pdfSrc]="src()" viewerId="quickstart" [theme]="theme.mode()"></ng2-pdfjs-viewer>
+    <ng2-pdfjs-viewer [pdfSrc]="src()" viewerId="quickstart" [theme]="theme.mode()" [chromeless]="chromeless()"></ng2-pdfjs-viewer>
   </div>
 
   <div controls>
+    <div class="ph">Embed style</div>
+    <div class="row">
+      <span>Chromeless <small style="opacity:.6">(pages only)</small></span>
+      <span class="switch" [class.on]="chromeless()" (click)="chromeless.set(!chromeless())"
+            role="switch" [attr.aria-checked]="chromeless()" tabindex="0"
+            (keydown.enter)="chromeless.set(!chromeless())" (keydown.space)="chromeless.set(!chromeless())"></span>
+    </div>
     <div class="ph">Install</div>
     <p class="hint">npm i ng2-pdfjs-viewer</p>
     <div class="ph">Steps</div>

--- a/playground/src/app/pages/quickstart/quickstart.component.ts
+++ b/playground/src/app/pages/quickstart/quickstart.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { PdfJsViewerModule } from 'ng2-pdfjs-viewer';
 import { CodeGenService } from '../../core/services/code-gen.service';
 import { SamplePdfService } from '../../core/services/sample-pdf.service';
@@ -22,10 +22,14 @@ export class QuickStartComponent {
   readonly theme = inject(ThemeService);
   readonly src = computed(() => this.samples.current().src);
 
+  // Embed style: chromeless drops the toolbar + sidebar for an inline preview.
+  readonly chromeless = signal(false);
+
   readonly code = computed(() =>
     this.codegen.generate([
       { name: 'pdfSrc', value: 'pdfSrc', kind: 'expr' },
       { name: 'viewerId', value: 'quickstart', kind: 'string' },
+      { name: 'chromeless', value: this.chromeless(), kind: 'boolean', omitWhen: false },
     ]),
   );
 }


### PR DESCRIPTION
Follow-up to #352. The Quick Start & Embed page is about embedding the viewer inline, so it now has an "Embed style" toggle for `chromeless` — flipping it strips the toolbar and sidebar for a pages-only inline preview, and the generated snippet picks up `[chromeless]="true"`.

Verified locally (Node 24, built against published 26.1.0): the page builds under strict templates and the toggle hides the chrome as expected.