### PR TITLE
chore(ci): keep playground + docs-website out of the Dependabot npm graph

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,10 @@
 #   - github-actions  the workflows that build, publish, and score the repo
 #
 # The non-shipped demo app and docs site (playground/, docs-website/) are
-# deliberately NOT listed here. Their
-# security ALERTS are auto-dismissed by a repository-level Dependabot auto-triage
-# rule that matches their manifest paths (configured in repo Settings -> Code security ->
-# Dependabot -> Auto-triage rules). Opening version-update PRs for them would
-# just add noise without affecting the published library's credibility.
+# deliberately NOT listed here, and are excluded from the npm dependency graph via
+# the `exclude-paths` key below — so their dev/build-tooling advisories don't raise
+# security alerts. Only /lib reaches users, and it ships with 0 runtime deps.
+# (Auto-triage rules can't match by manifest path, so exclude-paths is the lever.)
 version: 2
 updates:
   - package-ecosystem: "npm"
@@ -17,6 +16,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # Keep the non-shipped demo + docs out of the npm dependency graph so their
+    # dev-tooling advisories don't become security alerts (only /lib ships).
+    exclude-paths:
+      - "playground/**"
+      - "docs-website/**"
     groups:
       lib-dev-dependencies:
         patterns:


### PR DESCRIPTION
The published library (`lib/`) ships with 0 runtime dependencies, but the repo also vendors a demo app (`playground/`) and a Docusaurus docs site (`docs-website/`) whose dev/build tooling carries the usual stream of advisories. Those surfaced as ~20 Dependabot alerts even though none of them reach users of the npm package.

This adds `exclude-paths` to the npm entry in `.github/dependabot.yml` so `playground/**` and `docs-website/**` are kept out of the npm dependency-graph build, and therefore out of security alerts. Update PRs were already scoped to `/lib`.

It also corrects a stale comment: the previous note claimed a Dependabot auto-triage rule suppressed these by manifest path, but auto-triage rules can't match on path — which is why the alerts were still open.

Note: `exclude-paths` is a newer Dependabot key; if it doesn't fully take effect for npm, the fallback is a one-time bulk-dismiss of the existing demo/docs alerts.
