### PR TITLE
Homepage: render adopters as logo cards in the used-by strip

### DIFF
--- a/docs-website/src/pages/home.module.css
+++ b/docs-website/src/pages/home.module.css
@@ -21,11 +21,26 @@
 .inner { position: relative; z-index: 1; max-width: 1160px; margin: 0 auto; padding: 64px 24px 28px; }
 
 .usedBy { margin-top: 30px; padding-top: 24px; border-top: 1px solid var(--border); }
-.usedByLabel { font-family: var(--mono); font-size: 11.5px; text-transform: uppercase; letter-spacing: 0.09em; color: var(--muted); margin: 0 0 14px; }
-.usedByNames { display: flex; flex-wrap: wrap; gap: 10px 20px; align-items: center; }
-.usedByNames span { font-family: var(--display); font-weight: 600; font-size: 14px; color: var(--ink); opacity: 0.86; }
-.usedByMore { font-family: var(--display); font-weight: 600; font-size: 14px; color: var(--c); text-decoration: none; }
+.usedByLabel { font-family: var(--mono); font-size: 11.5px; text-transform: uppercase; letter-spacing: 0.09em; color: var(--muted); margin: 0 0 16px; }
+.usedByGrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+.usedByCard {
+  display: flex; gap: 12px; align-items: center; text-decoration: none; color: var(--ink);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.012));
+  border: 1px solid var(--border); border-radius: 12px; padding: 12px 14px; transition: 0.2s;
+}
+.usedByCard:hover { border-color: rgba(124, 92, 255, 0.45); transform: translateY(-2px); color: var(--ink); }
+.usedBySq {
+  width: 40px; height: 40px; flex: none; border-radius: 10px; display: flex; align-items: center; justify-content: center;
+  font-family: var(--display); font-weight: 700; font-size: 13px; color: #fff;
+}
+.usedByText { display: flex; flex-direction: column; min-width: 0; }
+.usedByName { font-family: var(--display); font-weight: 700; font-size: 14.5px; letter-spacing: -0.01em; color: var(--ink); }
+.usedByFlag { font-weight: 400; }
+.usedByDesc { font-size: 12px; color: var(--faint); margin-top: 2px; }
+.usedByMore { display: inline-block; margin-top: 16px; font-family: var(--display); font-weight: 600; font-size: 14px; color: var(--c); text-decoration: none; }
 .usedByMore:hover { color: var(--ink); }
+@media (max-width: 996px) { .usedByGrid { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 560px) { .usedByGrid { grid-template-columns: 1fr; } }
 
 .hero { display: grid; grid-template-columns: 1.04fr 0.96fr; gap: 48px; align-items: center; }
 .eyebrow {
@@ -124,6 +139,7 @@
 :global(html[data-theme='light']) .chip { background: #eef1f7; }
 :global(html[data-theme='light']) .vbody { background: linear-gradient(180deg, #eef1f7, #e4e8f1); }
 :global(html[data-theme='light']) .sheet { box-shadow: 0 18px 50px rgba(30, 40, 80, 0.18); }
-:global(html[data-theme='light']) .tile {
+:global(html[data-theme='light']) .tile,
+:global(html[data-theme='light']) .usedByCard {
   background: linear-gradient(180deg, rgba(20, 28, 56, 0.035), rgba(20, 28, 56, 0.012));
 }

--- a/docs-website/src/pages/index.tsx
+++ b/docs-website/src/pages/index.tsx
@@ -11,6 +11,16 @@ import styles from './home.module.css';
 const PLAYGROUND = 'https://demo.angularpdf.com/';
 const feat = (route: string) => `${PLAYGROUND}#/${route}`;
 
+// Marquee adopters for the homepage "used by" strip (a subset of /showcase).
+const ADOPTERS = [
+  { mono: 'EP', name: 'EPFL', flag: '🇨🇭', desc: 'Federal institute of technology', accent: '#b91c1c', url: 'https://infoscience.epfl.ch' },
+  { mono: 'CN', name: 'CNIL', flag: '🇫🇷', desc: 'Data-protection authority', accent: '#3b5bdb', url: 'https://github.com/LINCnil/pia' },
+  { mono: 'AOE', name: 'Finnish Agency for Education', flag: '🇫🇮', desc: 'National learning library', accent: '#0ea5b7', url: 'https://aoe.fi' },
+  { mono: 'AU', name: 'AuScope', flag: '🇦🇺', desc: 'Geoscience infrastructure', accent: '#16a34a', url: 'https://www.auscope.org.au/avre' },
+  { mono: 'MC', name: 'Spanish Ministry of Culture', flag: '🇪🇸', desc: 'Heritage digital library', accent: '#dc2626', url: 'https://travesia.mcu.es' },
+  { mono: 'UV', name: 'University of Virginia', flag: '🇺🇸', desc: 'Autism research registry', accent: '#e57200', url: 'https://autismdrive.virginia.edu' },
+];
+
 function Hero() {
   const { colorMode, setColorMode } = useColorMode();
   return (
@@ -107,15 +117,18 @@ function Hero() {
 
         <div className={styles.usedBy}>
           <p className={styles.usedByLabel}>In production on five continents</p>
-          <div className={styles.usedByNames}>
-            <span>EPFL</span>
-            <span>CNIL</span>
-            <span>Finnish National Agency for Education</span>
-            <span>AuScope</span>
-            <span>Spanish Ministry of Culture</span>
-            <span>UVA</span>
-            <Link className={styles.usedByMore} to="/showcase">See who's using it →</Link>
+          <div className={styles.usedByGrid}>
+            {ADOPTERS.map((a) => (
+              <a key={a.name} className={styles.usedByCard} href={a.url} target="_blank" rel="noopener noreferrer">
+                <span className={styles.usedBySq} style={{ background: `linear-gradient(135deg, ${a.accent}, ${a.accent}bb)` }}>{a.mono}</span>
+                <span className={styles.usedByText}>
+                  <span className={styles.usedByName}>{a.name} <span className={styles.usedByFlag}>{a.flag}</span></span>
+                  <span className={styles.usedByDesc}>{a.desc}</span>
+                </span>
+              </a>
+            ))}
           </div>
+          <Link className={styles.usedByMore} to="/showcase">See all 18 teams using it →</Link>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Replaces the flat row of adopter names on the homepage with a compact grid of horizontal logo cards, so the landing page carries more of the `/showcase` feel.

## What changed
- `index.tsx`: a small `ADOPTERS` array (six marquee institutions) rendered as a 3×2 grid. Each card is an accent logo-square + name + flag + a one-line descriptor, and links to the adopter's real production site (new tab, `rel="noopener noreferrer"`).
- `home.module.css`: card styles, responsive collapse (3 → 2 → 1 columns at 996px / 560px), and a light-mode override mirroring the existing `.tile` treatment.
- The footer link now reads "See all 18 teams using it →" and points to `/showcase`.

Verified locally in light and dark mode. Docs-site only — no library code, no npm release.
