### PR TITLE
Showcase: fix empty page, add flag images, tighten used-by copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,18 @@ That's the whole integration. [Wire up the assets](#-quick-start) and you have a
 ## 🌍 Used in production
 
 National regulators, public universities, research infrastructure, and fintech platforms render
-PDFs with ng2-pdfjs-viewer — on five continents. A few of the teams we can name:
+PDFs with ng2-pdfjs-viewer — on five continents. Among them:
 
 | | |
 |---|---|
-| 🇨🇭 **EPFL** | Switzerland's federal institute of technology — the Infoscience research portal |
-| 🇫🇷 **CNIL** | France's national data-protection authority |
-| 🇫🇮 **Finnish National Agency for Education** | the country's open learning-materials library (AOE) |
-| 🇦🇺 **AuScope** | Australia's national geoscience research infrastructure |
-| 🇪🇸 **Spain's Ministry of Culture** | the Travesía cultural-heritage platform |
-| 🇺🇸 **University of Virginia** | the Supporting Transformative Autism Research (DRIVE) program |
+| <img src="https://flagcdn.com/20x15/ch.png" width="20" alt="Switzerland"> **EPFL** | Switzerland's federal institute of technology — the Infoscience research portal |
+| <img src="https://flagcdn.com/20x15/fr.png" width="20" alt="France"> **CNIL** | France's national data-protection authority |
+| <img src="https://flagcdn.com/20x15/fi.png" width="20" alt="Finland"> **Finnish National Agency for Education** | the country's open learning-materials library (AOE) |
+| <img src="https://flagcdn.com/20x15/au.png" width="20" alt="Australia"> **AuScope** | Australia's national geoscience research infrastructure |
+| <img src="https://flagcdn.com/20x15/es.png" width="20" alt="Spain"> **Spain's Ministry of Culture** | the Travesía cultural-heritage platform |
+| <img src="https://flagcdn.com/20x15/us.png" width="20" alt="United States"> **University of Virginia** | the Supporting Transformative Autism Research (DRIVE) program |
 
-Those are the adopters we can point to by name. They sit inside **8.3M+ installs** worldwide — the
-named users we've confirmed so far span **13+ countries**, and that's the floor, not the ceiling.
-[See the full showcase →](https://angularpdf.com/showcase)
+Part of **8.3M+ installs** worldwide. [See the full showcase →](https://angularpdf.com/showcase)
 
 ## ✨ Highlights
 

--- a/docs-website/src/pages/home.module.css
+++ b/docs-website/src/pages/home.module.css
@@ -35,7 +35,7 @@
 }
 .usedByText { display: flex; flex-direction: column; min-width: 0; }
 .usedByName { font-family: var(--display); font-weight: 700; font-size: 14.5px; letter-spacing: -0.01em; color: var(--ink); }
-.usedByFlag { font-weight: 400; }
+.usedByFlag { width: 18px; height: auto; border-radius: 2px; margin-left: 1px; vertical-align: baseline; flex: none; }
 .usedByDesc { font-size: 12px; color: var(--faint); margin-top: 2px; }
 .usedByMore { display: inline-block; margin-top: 16px; font-family: var(--display); font-weight: 600; font-size: 14px; color: var(--c); text-decoration: none; }
 .usedByMore:hover { color: var(--ink); }

--- a/docs-website/src/pages/index.tsx
+++ b/docs-website/src/pages/index.tsx
@@ -13,12 +13,12 @@ const feat = (route: string) => `${PLAYGROUND}#/${route}`;
 
 // Marquee adopters for the homepage "used by" strip (a subset of /showcase).
 const ADOPTERS = [
-  { mono: 'EP', name: 'EPFL', flag: '🇨🇭', desc: 'Federal institute of technology', accent: '#b91c1c', url: 'https://infoscience.epfl.ch' },
-  { mono: 'CN', name: 'CNIL', flag: '🇫🇷', desc: 'Data-protection authority', accent: '#3b5bdb', url: 'https://github.com/LINCnil/pia' },
-  { mono: 'AOE', name: 'Finnish Agency for Education', flag: '🇫🇮', desc: 'National learning library', accent: '#0ea5b7', url: 'https://aoe.fi' },
-  { mono: 'AU', name: 'AuScope', flag: '🇦🇺', desc: 'Geoscience infrastructure', accent: '#16a34a', url: 'https://www.auscope.org.au/avre' },
-  { mono: 'MC', name: 'Spanish Ministry of Culture', flag: '🇪🇸', desc: 'Heritage digital library', accent: '#dc2626', url: 'https://travesia.mcu.es' },
-  { mono: 'UV', name: 'University of Virginia', flag: '🇺🇸', desc: 'Autism research registry', accent: '#e57200', url: 'https://autismdrive.virginia.edu' },
+  { mono: 'EP', name: 'EPFL', cc: 'ch', desc: 'Federal institute of technology', accent: '#b91c1c', url: 'https://infoscience.epfl.ch' },
+  { mono: 'CN', name: 'CNIL', cc: 'fr', desc: 'Data-protection authority', accent: '#3b5bdb', url: 'https://github.com/LINCnil/pia' },
+  { mono: 'AOE', name: 'Finnish Agency for Education', cc: 'fi', desc: 'National learning library', accent: '#0ea5b7', url: 'https://aoe.fi' },
+  { mono: 'AU', name: 'AuScope', cc: 'au', desc: 'Geoscience infrastructure', accent: '#16a34a', url: 'https://www.auscope.org.au/avre' },
+  { mono: 'MC', name: 'Spanish Ministry of Culture', cc: 'es', desc: 'Heritage digital library', accent: '#dc2626', url: 'https://travesia.mcu.es' },
+  { mono: 'UV', name: 'University of Virginia', cc: 'us', desc: 'Autism research registry', accent: '#e57200', url: 'https://autismdrive.virginia.edu' },
 ];
 
 function Hero() {
@@ -122,7 +122,7 @@ function Hero() {
               <a key={a.name} className={styles.usedByCard} href={a.url} target="_blank" rel="noopener noreferrer">
                 <span className={styles.usedBySq} style={{ background: `linear-gradient(135deg, ${a.accent}, ${a.accent}bb)` }}>{a.mono}</span>
                 <span className={styles.usedByText}>
-                  <span className={styles.usedByName}>{a.name} <span className={styles.usedByFlag}>{a.flag}</span></span>
+                  <span className={styles.usedByName}>{a.name} <img className={styles.usedByFlag} src={`https://flagcdn.com/20x15/${a.cc}.png`} width={18} height={14} alt="" loading="lazy" /></span>
                   <span className={styles.usedByDesc}>{a.desc}</span>
                 </span>
               </a>

--- a/docs-website/src/pages/showcase/index.tsx
+++ b/docs-website/src/pages/showcase/index.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import Layout from '@theme/Layout';
+import projectsData from '@site/data/projects.json';
 import styles from './showcase.module.css';
 
 interface Project {
@@ -29,19 +30,20 @@ const DEPENDENTS_URL = 'https://github.com/intbot/ng2-pdfjs-viewer/network/depen
 const monogram = (name: string) =>
   name.replace(/[^A-Za-z0-9 ]/g, '').trim().split(/\s+/).map((w) => w[0]).join('').slice(0, 2).toUpperCase();
 
+// Flag emoji → ISO 3166 alpha-2 (regional-indicator pair → letters), for flagcdn images.
+// Returns '' for anything that isn't a flag emoji, so the caller can skip rendering.
+const flagToCC = (flag?: string): string => {
+  if (!flag) return '';
+  const cps = [...flag].map((c) => c.codePointAt(0) || 0);
+  if (!cps.length || cps.some((cp) => cp < 0x1f1e6 || cp > 0x1f1ff)) return '';
+  return cps.map((cp) => String.fromCharCode(cp - 0x1f1e6 + 97)).join('');
+};
+
 export default function Showcase() {
-  const [projects, setProjects] = useState<Project[]>([]);
-  const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState('all');
 
-  useEffect(() => {
-    fetch('/data/projects.json')
-      .then((r) => (r.ok ? r.json() : []))
-      .then((data: Project[]) => setProjects(data.filter((p) => p.status === 'approved')))
-      .catch(() => setProjects([]))
-      .finally(() => setLoading(false));
-  }, []);
-
+  // projects.json is bundled at build time (a runtime fetch of /data/ 404s — it isn't a static asset).
+  const projects = (projectsData as unknown as Project[]).filter((p) => p.status === 'approved');
   const industries = ['all', ...Array.from(new Set(projects.map((p) => p.industry)))];
   const countryCount = new Set(projects.map((p) => p.country).filter(Boolean)).size;
   const shown = filter === 'all' ? projects : projects.filter((p) => p.industry === filter);
@@ -65,7 +67,7 @@ export default function Showcase() {
             in production. Curated from public usage; add yours below.
           </p>
 
-          {!loading && projects.length > 0 && (
+          {projects.length > 0 && (
             <div className={styles.stats}>
               <div>
                 <b>{projects.length}</b>
@@ -100,9 +102,7 @@ export default function Showcase() {
             </div>
           )}
 
-          {loading ? (
-            <p className={styles.empty}>Loading projects…</p>
-          ) : shown.length === 0 ? (
+          {shown.length === 0 ? (
             <p className={styles.empty}>No projects in this category yet.</p>
           ) : (
             <div className={styles.grid}>
@@ -129,7 +129,10 @@ export default function Showcase() {
                   <div className={styles.body}>
                     <div className={styles.name}>
                       <span className={styles.dot} style={{ background: p.accent || '#7c5cff' }} />
-                      {p.name} {p.flag || ''}
+                      {p.name}
+                      {flagToCC(p.flag) && (
+                        <img className={styles.flag} src={`https://flagcdn.com/20x15/${flagToCC(p.flag)}.png`} width={20} height={15} alt="" loading="lazy" />
+                      )}
                     </div>
                     <div className={styles.desc}>{p.description}</div>
                     <div className={styles.meta}>

--- a/docs-website/src/pages/showcase/showcase.module.css
+++ b/docs-website/src/pages/showcase/showcase.module.css
@@ -42,6 +42,7 @@
 .body { padding: 18px; }
 .name { display: flex; align-items: center; gap: 9px; font-weight: 700; font-size: 17px; letter-spacing: -0.01em; }
 .dot { width: 9px; height: 9px; border-radius: 50%; flex: none; }
+.flag { width: 20px; height: 15px; border-radius: 2px; flex: none; }
 .desc { color: var(--muted); font-size: 14px; margin: 8px 0 14px; line-height: 1.5; }
 .meta { display: flex; justify-content: space-between; align-items: center; gap: 8px; font-family: var(--mono); font-size: 12px; color: var(--faint); }
 .tag { font-family: var(--mono); font-size: 11px; color: var(--muted); border: 1px solid var(--border); padding: 2px 8px; border-radius: 6px; white-space: nowrap; }


### PR DESCRIPTION
Three related fixes to the showcase and used-by surfaces. Docs-site + README only — no library code, no npm release.

## Fix the empty `/showcase` page
The page fetched `/data/projects.json` at runtime, but that file lives in `data/` and was never deployed (Docusaurus only serves `static/`), so the fetch 404'd and the grid rendered empty. The JSON is now imported at build time (`@site/data/projects.json`) and bundled into the page — no runtime fetch, identical in dev and prod.

## Flag images instead of emoji
Flag emoji render as two-letter codes on Windows and on the npm page, where the system emoji font has no flag glyphs. Replaced them with small inline flag images (flagcdn.com) on the README, the homepage used-by cards, and the showcase cards, so real flags show on every platform. The showcase derives each country code from the existing flag emoji via a small helper, so no data migration was needed.

## Used-by copy
Reworded the README "Used in production" section to drop the precise country count (which read as a cap next to "8.3M+ installs worldwide") and the hedging phrasing.

Verified locally in light and dark mode.
