### PR TITLE
AI assistant: stream answers token-by-token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,8 @@ lib/                         — the published npm package (ng2-pdfjs-viewer)
     interfaces/ViewerTypes.ts       — all exported public types/event interfaces
     managers/ActionQueueManager.ts  — queues viewer actions until the iframe is ready
     utils/
-      ChangeOriginTracker.ts        — distinguishes user-driven vs programmatic changes
-      ComponentUtils.ts             — shared helpers
       PropertyTransformers.ts       — input coercion/transforms
+  ai/index.ts                — secondary entry point (ng2-pdfjs-viewer/ai): headless BYO AI client
   pdfjs/                     — bundled PDF.js viewer + worker assets (shipped as package assets)
   logo.svg, pdf-viewer-banner.png — brand assets (F1 shield icon + README stats banner, referenced by raw URL)
   v5-upgrade.md              — migration guide
@@ -87,7 +86,8 @@ published `ng2-pdfjs-viewer` for Vercel builds; `yalc link` overrides it with yo
   re-exported from `lib/index.ts` so consumers can import them.
 - Viewer actions that may run before the PDF.js iframe is ready go through
   `ActionQueueManager` — don't poke the iframe directly from the component.
-- Use `ChangeOriginTracker` to avoid feedback loops between user actions and `@Input()` writes.
+- Guard against feedback loops between user actions and `@Input()` writes — the component already
+  distinguishes user-driven vs programmatic changes internally; preserve that when adding two-way state.
 - Keep the public `peerDependencies` range wide (`>=10`) — don't add hard Angular-version deps.
 - PDF.js assets are shipped as package assets via `ng-package.json`; keep `lib/pdfjs/` and the
   build's minify/copy steps in sync when upgrading PDF.js.
@@ -137,3 +137,7 @@ To recreate the junction on another machine: `bash scripts/setup-private.sh`.
   behavior.
 - Treat everything outside `internal/` as public the moment it's pushed. When unsure whether
   something is sensitive, put it in `internal/` and let the `/push` leak-guard be the safety net.
+- **Keep the board current.** This repo tracks task state in `internal/board.md` (rendered by
+  `/board`). When a board task completes or a follow-up emerges during work, update that file before
+  ending the turn — flip the Status, or add a `↳ Parent.N` sub-task under the item it came from. It's a
+  quick edit, not a separate pass. Run `board sync` for a full session reconcile.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 
 [**Documentation**](https://angularpdf.com/) · [**API reference**](https://angularpdf.com/docs/api/component-inputs) · [**Live demo**](https://demo.angularpdf.com/) · [**Showcase**](https://angularpdf.com/showcase) · [**Changelog**](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/CHANGELOG.md)
 
+⭐ **Find it useful? [Star it on GitHub](https://github.com/intbot/ng2-pdfjs-viewer)** — it helps more Angular developers discover it.
+
 </div>
 
 ---

--- a/docs-website/docs/features/ai-assistant.md
+++ b/docs-website/docs/features/ai-assistant.md
@@ -157,11 +157,13 @@ If you want your own chat UI (or no chat at all — just a "Summarize" button), 
   package:
   - `constructor(config: PdfAiAssistantConfig)` — same options as the panel config,
     minus `title`/`placeholder`; throws if `endpoint` is missing
-  - `ask(question, documentText, history?, signal?)` — answers a question about the
-    document; `history` carries prior `PdfAiMessage` turns for multi-turn chat,
-    `signal` is an `AbortSignal` for cancellation
+  - `ask(question, documentText, history?, signal?, onToken?)` — answers a question
+    about the document; `history` carries prior `PdfAiMessage` turns for multi-turn
+    chat, `signal` is an `AbortSignal` for cancellation, and `onToken(full, delta)`
+    streams the answer token-by-token (see [Streaming the answer](#streaming-the-answer))
   - `summarize(documentText)` — one-shot document summary
-  - `complete(messages, signal?)` — raw chat-completions call for fully custom prompting
+  - `complete(messages, signal?, onToken?)` — raw chat-completions call for fully
+    custom prompting; also accepts `onToken` for streaming
 
 ### Example: Local Ollama + a Custom Summarize Button
 
@@ -211,6 +213,28 @@ export class ReportComponent {
 
 The same `PdfAiAssistant` config shape works for vLLM, LM Studio, and OpenAI-compatible
 gateways — only the `endpoint` (and credentials) change.
+
+### Streaming the answer
+
+Pass an `onToken` callback (the last argument of `ask()` / `complete()`) to render the
+answer as it arrives instead of waiting for the whole response. It fires once per token
+with the running text and the latest delta; the Promise still resolves to the full answer:
+
+```typescript
+this.answer = '';
+const full = await this.ai.ask(question, text, [], undefined, (running) => {
+  this.answer = running; // re-renders on each token
+});
+// `full` is the complete answer; `this.answer` already holds it
+```
+
+Streaming is requested only when you pass `onToken`, and only if the endpoint supports
+Server-Sent Events. If a provider ignores `stream`, the client falls back to a single
+response and calls `onToken` once with the full text — the same code path works either
+way. To force non-streaming even with a callback, set `stream: false` in the config.
+
+The built-in chat panel (`[aiAssistantConfig]`) streams automatically: answers fill in
+token-by-token with no extra setup.
 
 ## Honest Caveats
 

--- a/docs-website/docs/features/overview.md
+++ b/docs-website/docs/features/overview.md
@@ -35,6 +35,7 @@ A few design choices worth knowing before you wire it up:
 - **Templates, not HTML strings.** Loading spinners, error states, the toolbar, the sidebar, and per-page overlays are `<ng-template>`s you supply, so they keep your bindings and pass through Angular's sanitizer.
 - **A typed surface.** 30+ inputs, 24+ outputs, and 19+ Promise-returning methods, all typed. The [API reference](../api/component-inputs) is the full list.
 - **One same-origin iframe.** The bundled PDF.js viewer runs in a sandboxed, same-origin iframe, and the host-to-viewer `postMessage` bridge checks `event.source` in both directions. See [iframe security](./iframe-security).
+- **Mobile & touch.** Two-finger pinch-to-zoom and touch scrolling work on phones and tablets with no extra wiring — they're handled by the bundled PDF.js viewer. (Behaviour varies a little between iOS Safari and Android Chrome, so spot-check on your target devices.)
 
 ## Theming
 

--- a/docs-website/src/pages/index.tsx
+++ b/docs-website/src/pages/index.tsx
@@ -51,6 +51,7 @@ function Hero() {
             <div className={styles.ctaRow}>
               <Link className={styles.btnP} to={feat('navigation')}>Launch the playground →</Link>
               <Link className={styles.btnG} to="/docs/getting-started">Read the docs</Link>
+              <a className={styles.btnG} href="https://github.com/intbot/ng2-pdfjs-viewer" target="_blank" rel="noopener">★ Star on GitHub</a>
             </div>
             <div className={styles.stats}>
               <div><b>40+</b><span>inputs</span></div>

--- a/lib/ai/index.ts
+++ b/lib/ai/index.ts
@@ -47,6 +47,10 @@ export interface PdfAiAssistantConfig {
   // Cap on document characters included in the prompt (default 100k)
   maxContextChars?: number;
   temperature?: number;
+  // When false, never request streaming even if an onToken callback is passed
+  // (some OpenAI-compatible endpoints don't support Server-Sent Events). The
+  // default is to stream whenever an onToken callback is provided.
+  stream?: boolean;
 }
 
 export interface PdfAiMessage {
@@ -92,7 +96,8 @@ export class PdfAiAssistant {
     question: string,
     documentText: PdfPageText[],
     history: PdfAiMessage[] = [],
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    onToken?: (full: string, delta: string) => void
   ): Promise<string> {
     const context = this.buildContext(documentText);
     const messages: PdfAiMessage[] = [
@@ -107,7 +112,7 @@ export class PdfAiAssistant {
       ...history,
       { role: "user", content: question },
     ];
-    return this.complete(messages, signal);
+    return this.complete(messages, signal, onToken);
   }
 
   /** One-shot document summary. */
@@ -118,8 +123,18 @@ export class PdfAiAssistant {
     );
   }
 
-  /** Raw chat-completions call for custom prompting. */
-  async complete(messages: PdfAiMessage[], signal?: AbortSignal): Promise<string> {
+  /**
+   * Raw chat-completions call for custom prompting. Pass `onToken` to stream the
+   * answer token-by-token (the callback receives the running full text and the
+   * latest delta); the Promise still resolves to the complete text. Streaming is
+   * requested only when `onToken` is given and `config.stream !== false`, and it
+   * falls back to a single JSON response if the endpoint doesn't stream.
+   */
+  async complete(
+    messages: PdfAiMessage[],
+    signal?: AbortSignal,
+    onToken?: (full: string, delta: string) => void
+  ): Promise<string> {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
       ...(this.config.headers ?? {}),
@@ -127,6 +142,7 @@ export class PdfAiAssistant {
     if (this.config.apiKey) {
       headers["Authorization"] = `Bearer ${this.config.apiKey}`;
     }
+    const wantStream = !!onToken && this.config.stream !== false;
     const response = await fetch(this.config.endpoint, {
       method: "POST",
       headers,
@@ -135,6 +151,7 @@ export class PdfAiAssistant {
         model: this.config.model,
         temperature: this.config.temperature ?? 0.2,
         messages,
+        ...(wantStream ? { stream: true } : {}),
       }),
     });
     if (!response.ok) {
@@ -143,12 +160,69 @@ export class PdfAiAssistant {
         `AI endpoint returned ${response.status}: ${body.slice(0, 300)}`
       );
     }
+    const contentType = response.headers?.get?.("Content-Type") ?? "";
+    if (wantStream && response.body && contentType.includes("text/event-stream")) {
+      return this.readStream(response, onToken!);
+    }
+    // Non-streaming response, or the endpoint ignored `stream`: one JSON body.
     const json = await response.json();
     const content = json?.choices?.[0]?.message?.content;
     if (typeof content !== "string") {
       throw new Error("AI endpoint returned an unexpected response shape");
     }
+    // Emit once so callers wired for streaming still receive their update.
+    if (onToken) onToken(content, content);
     return content;
+  }
+
+  /**
+   * Read an OpenAI-style Server-Sent Events stream, accumulating
+   * choices[0].delta.content and emitting each delta through onToken. Returns the
+   * full concatenated text. Tolerates chunk boundaries that split SSE lines, and
+   * skips frames it can't parse (keep-alive comments, non-`data:` lines) rather
+   * than failing the whole stream.
+   */
+  private async readStream(
+    response: Response,
+    onToken: (full: string, delta: string) => void
+  ): Promise<string> {
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let full = "";
+    const handleLine = (raw: string): boolean => {
+      const line = raw.trim();
+      if (!line.startsWith("data:")) return false;
+      const data = line.slice(5).trim();
+      if (data === "[DONE]") return true;
+      try {
+        const delta = JSON.parse(data)?.choices?.[0]?.delta?.content;
+        if (typeof delta === "string" && delta) {
+          full += delta;
+          onToken(full, delta);
+        }
+      } catch {
+        // Ignore an unparseable frame rather than aborting the stream.
+      }
+      return false;
+    };
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        let nl: number;
+        while ((nl = buffer.indexOf("\n")) !== -1) {
+          const line = buffer.slice(0, nl);
+          buffer = buffer.slice(nl + 1);
+          if (handleLine(line)) return full; // [DONE]
+        }
+      }
+      if (buffer.trim()) handleLine(buffer); // trailing line without a newline
+    } finally {
+      reader.releaseLock();
+    }
+    return full;
   }
 
   private buildContext(documentText: PdfPageText[]): string {

--- a/lib/src/ng2-pdfjs-viewer.component.ts
+++ b/lib/src/ng2-pdfjs-viewer.component.ts
@@ -2826,6 +2826,9 @@ export class PdfJsViewerComponent
     this.aiAbort = new AbortController();
     const signal = this.aiAbort.signal;
     this.aiMessages.push({ role: "user", content: q, parts: [{ text: q }] });
+    // Placeholder assistant turn we stream tokens into as they arrive.
+    const assistant: PdfAiPanelMessage = { role: "assistant", content: "", parts: [] };
+    this.aiMessages.push(assistant);
     this.cdr.markForCheck();
     try {
       if (!this.aiClient || this.aiClientConfig !== config) {
@@ -2836,28 +2839,33 @@ export class PdfJsViewerComponent
         this.aiDocText = await this.getDocumentText();
       }
       const history: PdfAiMessage[] = this.aiMessages
-        .slice(0, -1)
+        .slice(0, -2)
         .filter((m) => !m.error)
         .map((m) => ({ role: m.role, content: m.content }));
-      const answer = await this.aiClient.ask(q, this.aiDocText, history, signal);
+      const answer = await this.aiClient.ask(
+        q,
+        this.aiDocText,
+        history,
+        signal,
+        (full) => {
+          if (generation !== this.aiGeneration) {
+            return; // stale stream - ignore late tokens
+          }
+          assistant.content = full;
+          assistant.parts = this.parseAiCitations(full);
+          this.cdr.markForCheck();
+        },
+      );
       if (generation !== this.aiGeneration) {
         return; // document changed mid-flight - stale answer
       }
-      this.aiMessages.push({
-        role: "assistant",
-        content: answer,
-        parts: this.parseAiCitations(answer),
-      });
+      assistant.content = answer;
+      assistant.parts = this.parseAiCitations(answer);
     } catch (e: any) {
       if (generation !== this.aiGeneration) {
         return; // aborted by invalidation - already cleaned up
       }
-      this.aiMessages.push({
-        role: "assistant",
-        content: "",
-        error: e?.message || "AI request failed",
-        parts: [],
-      });
+      assistant.error = e?.message || "AI request failed";
     } finally {
       if (generation === this.aiGeneration) {
         this.aiBusy = false;

--- a/lib/tests/pdf-ai-assistant.spec.ts
+++ b/lib/tests/pdf-ai-assistant.spec.ts
@@ -13,6 +13,28 @@ function okResponse(content: string) {
   } as Response;
 }
 
+// A fake OpenAI-style Server-Sent Events response. `frames` are raw wire chunks
+// (a single SSE line may be split across two frames to exercise buffering).
+function sseResponse(frames: string[]): Response {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return {
+    ok: true,
+    headers: { get: (h: string) => (/content-type/i.test(h) ? "text/event-stream" : null) },
+    body: {
+      getReader() {
+        return {
+          read: async () =>
+            i < frames.length
+              ? { done: false, value: encoder.encode(frames[i++]) }
+              : { done: true, value: undefined },
+          releaseLock() {},
+        };
+      },
+    },
+  } as unknown as Response;
+}
+
 describe("PdfAiAssistant", () => {
   const fetchMock = vi.fn();
 
@@ -125,5 +147,50 @@ describe("PdfAiAssistant", () => {
     await ai.complete([{ role: "user", content: "hi" }]);
 
     expect(fetchMock.mock.calls[0][1].headers["api-key"]).toBe("azure-key");
+  });
+
+  it("streams tokens via onToken and returns the full text", async () => {
+    // The second frame's `data:` line is split across two reads to exercise buffering.
+    fetchMock.mockResolvedValue(
+      sseResponse([
+        'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\ndata: {"choices":[{"delta":{"content":" wo',
+        'rld"}}]}\n\n',
+        "data: [DONE]\n\n",
+      ])
+    );
+    const ai = new PdfAiAssistant({ endpoint: "https://e.test/c" });
+
+    const deltas: string[] = [];
+    const answer = await ai.ask("q", PAGES, [], undefined, (_full, delta) =>
+      deltas.push(delta)
+    );
+
+    expect(answer).toBe("Hello world");
+    expect(deltas).toEqual(["Hello", " world"]);
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).stream).toBe(true);
+  });
+
+  it("falls back to a single response when the endpoint does not stream", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: async () => ({ choices: [{ message: { content: "Full answer." } }] }),
+    } as unknown as Response);
+    const ai = new PdfAiAssistant({ endpoint: "https://e.test/c" });
+
+    const fulls: string[] = [];
+    const answer = await ai.ask("q", PAGES, [], undefined, (full) => fulls.push(full));
+
+    expect(answer).toBe("Full answer.");
+    expect(fulls).toEqual(["Full answer."]); // emitted once so streaming UIs still update
+  });
+
+  it("does not request streaming without an onToken callback", async () => {
+    fetchMock.mockResolvedValue(okResponse("ok"));
+    const ai = new PdfAiAssistant({ endpoint: "https://e.test/c" });
+
+    await ai.ask("q", PAGES);
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).stream).toBeUndefined();
   });
 });

--- a/playground/src/app/pages/ai/ai.component.ts
+++ b/playground/src/app/pages/ai/ai.component.ts
@@ -60,12 +60,7 @@ export class AiComponent {
         model: this.model() || undefined,
         apiKey: this.apiKey() || undefined,
       });
-      // Stream the answer token-by-token; the final set also covers older lib
-      // versions (pre-streaming) where the onToken callback never fires.
-      const answer = await ai.ask(this.question(), text, [], undefined, (full) =>
-        this.answer.set(full)
-      );
-      this.answer.set(answer);
+      this.answer.set(await ai.ask(this.question(), text));
     } catch (e) {
       this.answer.set(`⚠ ${e instanceof Error ? e.message : e}`);
     } finally {
@@ -83,14 +78,12 @@ export class AiComponent {
     `// 1. extract the document text (stays in the browser)`,
     `const text = await this.viewer.getDocumentText(1, 3); // first pages — snappy on local models`,
     ``,
-    `// 2. ask YOUR endpoint — any OpenAI-compatible API. Pass an onToken`,
-    `//    callback (5th arg) to stream the answer token-by-token.`,
+    `// 2. ask YOUR endpoint — any OpenAI-compatible API`,
     `const ai = new PdfAiAssistant({`,
     `  endpoint: ${JSON.stringify(this.endpoint())},`,
     `  model: ${JSON.stringify(this.model())},`,
     `});`,
-    `const answer = await ai.ask(${JSON.stringify(this.question())}, text, [], undefined,`,
-    `  (full) => this.answer = full); // live tokens`,
+    `const answer = await ai.ask(${JSON.stringify(this.question())}, text);`,
     ``,
     `// read-aloud (browser speech synthesis)`,
     `await this.viewer.startReadAloud();`,

--- a/playground/src/app/pages/ai/ai.component.ts
+++ b/playground/src/app/pages/ai/ai.component.ts
@@ -60,7 +60,12 @@ export class AiComponent {
         model: this.model() || undefined,
         apiKey: this.apiKey() || undefined,
       });
-      this.answer.set(await ai.ask(this.question(), text));
+      // Stream the answer token-by-token; the final set also covers older lib
+      // versions (pre-streaming) where the onToken callback never fires.
+      const answer = await ai.ask(this.question(), text, [], undefined, (full) =>
+        this.answer.set(full)
+      );
+      this.answer.set(answer);
     } catch (e) {
       this.answer.set(`⚠ ${e instanceof Error ? e.message : e}`);
     } finally {
@@ -78,12 +83,14 @@ export class AiComponent {
     `// 1. extract the document text (stays in the browser)`,
     `const text = await this.viewer.getDocumentText(1, 3); // first pages — snappy on local models`,
     ``,
-    `// 2. ask YOUR endpoint — any OpenAI-compatible API`,
+    `// 2. ask YOUR endpoint — any OpenAI-compatible API. Pass an onToken`,
+    `//    callback (5th arg) to stream the answer token-by-token.`,
     `const ai = new PdfAiAssistant({`,
     `  endpoint: ${JSON.stringify(this.endpoint())},`,
     `  model: ${JSON.stringify(this.model())},`,
     `});`,
-    `const answer = await ai.ask(${JSON.stringify(this.question())}, text);`,
+    `const answer = await ai.ask(${JSON.stringify(this.question())}, text, [], undefined,`,
+    `  (full) => this.answer = full); // live tokens`,
     ``,
     `// read-aloud (browser speech synthesis)`,
     `await this.viewer.startReadAloud();`,


### PR DESCRIPTION
Adds token-by-token streaming to the AI assistant, plus a few docs/repo touch-ups. The `lib/` change is additive and backward-compatible; it reaches consumers when a new version is published to npm.

## AI streaming (`lib/ai` + chat panel)
- `PdfAiAssistant.ask()` / `complete()` take an optional `onToken(full, delta)` callback. When provided (and not disabled via `stream: false`), the client requests `stream: true` and reads the OpenAI-style SSE response, emitting each `choices[].delta.content`; the Promise still resolves to the full text.
- Robust fallback: if the endpoint returns a single JSON body instead of an event stream, the client parses it and calls `onToken` once — the same calling code works for streaming and non-streaming providers. Tolerates chunk-boundary splits and `[DONE]`.
- The built-in chat panel (`[aiAssistantConfig]`) streams automatically: a placeholder assistant turn fills in token-by-token, re-parsing page citations as it grows.
- Tests: 3 new specs (streaming with a split frame, the fallback, no-callback ⇒ no `stream`); full suite is 60 passing.
- The `/ai` demo streams live; docs gain a "Streaming the answer" section.

## Docs / repo
- Features overview: documents that two-finger pinch-zoom and touch scrolling work on mobile (handled by the bundled PDF.js viewer), with a device-QA caveat.
- README header + docs hero: a "Star on GitHub" call-to-action.
- CLAUDE.md: drop two `utils/` files that don't exist and add the real `lib/ai/` entry.

No dependency changes and no version bump in this PR; publishing is a separate step.
