### PR TITLE
Add ng2-pdfjs-viewer/signals: read viewer state as Angular signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `ng2-pdfjs-viewer/signals`: a new entry point that projects viewer state — current
+  page, zoom, total pages, search matches, read-aloud progress, annotation-editor
+  state, sidebar, metadata, form data, and the view-mode strings — as read-only
+  Angular signals. Call `pdfViewerSignals(viewer, { injector })` and read
+  `signals.page()`, `signals.totalPages()`, `signals.loaded()` in a template, or
+  build `computed`/`effect` on top. Aimed at zoneless / OnPush apps. Requires
+  Angular 16+; the base package's `>=10` peer range is unchanged.
+- AI assistant streaming: `PdfAiAssistant.ask()` and `complete()` take an optional
+  `onToken` callback and stream the answer token-by-token over Server-Sent Events,
+  falling back to a single response when the endpoint doesn't stream. The built-in
+  chat panel renders the answer as it arrives.
+
 ## [26.1.1] - 2026-06-23
 
 ### Changed

--- a/docs-website/docs/features/overview.md
+++ b/docs-website/docs/features/overview.md
@@ -20,6 +20,7 @@ Most of what you reach for in a PDF viewer is a declarative input or output here
 | **AI assistant (your endpoint)** | Chat panel with clickable page citations against your OpenAI-compatible endpoint. The library makes no vendor calls of its own. | [AI assistant](./ai-assistant) |
 | **Read aloud** | Sentence-by-sentence text-to-speech with in-page highlighting. | [Read aloud](./read-aloud) |
 | **Custom toolbar, sidebar & overlays** | Replace the viewer chrome with your Angular templates, project templates onto every page, or drop the chrome entirely with `chromeless` for an embedded pages-only view. | [Custom UI](./custom-ui) |
+| **Signals (zoneless / OnPush)** | Read viewer state — page, zoom, search matches, read-aloud, more — as Angular signals from `ng2-pdfjs-viewer/signals` (Angular 16+). | [Signals](./signals) |
 | **Content protection** | Block print, download, and text selection; stamp watermarks. Client-side deterrence, not DRM. | [Content protection](./content-protection) |
 | **Authenticated loading** | `httpHeaders`/`withCredentials`, download progress, password-prompt events. | [Loading documents](./loading-documents) |
 | **Localization** | Locale detection, RTL, and overridable UI strings via `locale`. | [Component inputs](../api/component-inputs) |

--- a/docs-website/docs/features/signals.md
+++ b/docs-website/docs/features/signals.md
@@ -1,0 +1,100 @@
+---
+description: "Read viewer state as Angular signals — current page, zoom, search matches, read-aloud progress, and more — for zoneless and OnPush apps, from the ng2-pdfjs-viewer/signals entry point."
+keywords: [angular pdf signals, zoneless pdf viewer angular, onpush pdf viewer, angular pdf viewer state]
+---
+
+# Signals (zoneless / OnPush)
+
+Every piece of viewer state the component emits is also available as a read-only Angular signal. Instead of wiring up `(onPageChange)`, `(onScaleChange)`, and a dozen other bindings — each pushing into a field you then read in the template — you call one function and read `signals.page()`, `signals.totalPages()`, `signals.loaded()` directly.
+
+This lives in a separate entry point so the base package keeps its `>=10` peer range. Signals and `@angular/core/rxjs-interop` arrived in Angular 16, so **this feature needs Angular 16+**. Apps on older Angular never load it.
+
+```typescript
+import { pdfViewerSignals, PdfViewerSignals } from 'ng2-pdfjs-viewer/signals';
+```
+
+## Wire it up
+
+A `@ViewChild` reference is only populated in `ngAfterViewInit`, which is **not** an Angular injection context. `toSignal` needs one (to clean up its subscriptions when the host is destroyed), so capture an `Injector` earlier and hand it over:
+
+```typescript
+import { Component, ViewChild, Injector, inject, AfterViewInit } from '@angular/core';
+import { PdfJsViewerComponent } from 'ng2-pdfjs-viewer';
+import { pdfViewerSignals, PdfViewerSignals } from 'ng2-pdfjs-viewer/signals';
+
+@Component({
+  selector: 'app-reader',
+  template: `
+    <ng2-pdfjs-viewer #viewer pdfSrc="/docs/report.pdf"></ng2-pdfjs-viewer>
+
+    @if (signals?.loaded()) {
+      <footer>Page {{ signals.page() }} of {{ signals.totalPages() }} · {{ signals.scale() | percent }}</footer>
+    }
+  `,
+})
+export class ReaderComponent implements AfterViewInit {
+  @ViewChild('viewer') viewer!: PdfJsViewerComponent;
+  private injector = inject(Injector);
+  signals!: PdfViewerSignals;
+
+  ngAfterViewInit() {
+    this.signals = pdfViewerSignals(this.viewer, { injector: this.injector });
+  }
+}
+```
+
+Call it from a constructor or field initializer (where an injection context already exists) and the `injector` option can be dropped — but the `@ViewChild` is `undefined` that early, so `ngAfterViewInit` with an explicit injector is the usual path.
+
+## What you get
+
+Each signal holds the **latest** value from its source output and starts as `undefined` until that output first fires. `loaded` and `totalPages` are derived from page initialization, so `loaded` starts `false`.
+
+| Signal | Type | Source |
+| --- | --- | --- |
+| `page` | `number \| undefined` | current 1-based page |
+| `scale` | `number \| undefined` | zoom factor (1 = 100%) |
+| `totalPages` | `number \| undefined` | page count, once pages init |
+| `loaded` | `boolean` | `true` once pages init |
+| `error` | `DocumentError \| undefined` | last load error |
+| `rotation` | `ChangedRotation \| undefined` | `{ rotation, page }` |
+| `findMatches` | `FindMatchesCount \| undefined` | `{ current, total }` |
+| `readAloud` | `ReadAloudState \| undefined` | `{ status, page, sentence? }` |
+| `annotationEditor` | `AnnotationEditorState \| undefined` | undo/empty/selection state |
+| `annotationEditorMode` | `AnnotationEditorMode \| undefined` | active tool (highlight, ink, …) |
+| `sidebar` | `SidebarViewChange \| undefined` | `{ view }` |
+| `metadata` | `DocumentMetadata \| undefined` | title, author, … |
+| `outline` | `DocumentOutline \| undefined` | bookmarks |
+| `formData` | `FormDataMap \| undefined` | current AcroForm values |
+| `presentationMode` | `PresentationMode \| undefined` | `{ active }` |
+| `zoom` `cursor` `scroll` `spread` `pageMode` | `string \| undefined` | view-mode strings |
+
+The payload types (`ChangedRotation`, `FindMatchesCount`, …) come from the main package — import them from `ng2-pdfjs-viewer`.
+
+## Composing derived state
+
+Because these are real signals, `computed` and `effect` work as you'd expect — no manual change detection, no `markForCheck`:
+
+```typescript
+import { computed, effect } from '@angular/core';
+
+// A "X matches on this page" label that recomputes only when search changes.
+readonly matchSummary = computed(() => {
+  const m = this.signals.findMatches();
+  return m ? `${m.current} of ${m.total}` : 'No search';
+});
+
+// React to read-aloud finishing.
+constructor() {
+  effect(() => {
+    if (this.signals?.readAloud()?.status === 'finished') {
+      // ...
+    }
+  });
+}
+```
+
+## Notes
+
+- **Read-only.** These signals report state; they don't set it. To drive the viewer, use its `@Input()`s and methods (e.g. `[(page)]`, `goToPage()`, `search()`).
+- **Cleanup is automatic.** Subscriptions are tied to the injector's `DestroyRef`, so they're released when the host component is destroyed.
+- **The outputs still work.** This is a projection of the same `@Output()` events — bind to them directly if you'd rather, or mix both.

--- a/docs-website/sidebars.ts
+++ b/docs-website/sidebars.ts
@@ -31,6 +31,7 @@ const sidebars: SidebarsConfig = {
         'features/ai-assistant',
         'features/read-aloud',
         'features/custom-ui',
+        'features/signals',
         'features/content-protection',
         'features/accessibility',
         'features/theming',

--- a/lib/signals/index.ts
+++ b/lib/signals/index.ts
@@ -1,0 +1,156 @@
+// Secondary entry point: ng2-pdfjs-viewer/signals
+//
+// Read-only Angular signals projected from the viewer's @Output() events, for
+// zoneless and OnPush apps that prefer reading state from signals over wiring up
+// a handful of (event)="..." bindings and EventEmitter subscriptions.
+//
+// It reads the same outputs the component already emits - it adds no new viewer
+// behaviour and sends nothing anywhere. Each signal holds the latest value from
+// its source output and starts as `undefined` until that output first fires
+// (`loaded`/`totalPages` are derived from page initialization).
+//
+// Requires Angular 16+ (signals + `@angular/core/rxjs-interop`). The base package
+// keeps its `>=10` peer range; only this entry point needs 16+, so import it from
+// the subpath and apps on older Angular never load it:
+//
+//   import { pdfViewerSignals } from "ng2-pdfjs-viewer/signals";
+//
+// A @ViewChild viewer is only populated in ngAfterViewInit, which is NOT an
+// injection context, so pass an Injector captured earlier:
+//
+//   @ViewChild('viewer') viewer!: PdfJsViewerComponent;
+//   private injector = inject(Injector);
+//   signals!: PdfViewerSignals;
+//
+//   ngAfterViewInit() {
+//     this.signals = pdfViewerSignals(this.viewer, { injector: this.injector });
+//   }
+//   // template: {{ signals.page() }} / {{ signals.totalPages() }} / {{ signals.loaded() }}
+//
+// Called from a constructor or field initializer (where an injection context
+// exists), the `injector` option can be omitted. Subscriptions are torn down with
+// the injector's DestroyRef - i.e. when the host component is destroyed.
+
+import { computed, EventEmitter, Injector, Signal } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
+import type {
+  AnnotationEditorMode,
+  AnnotationEditorState,
+  ChangedRotation,
+  DocumentError,
+  DocumentMetadata,
+  DocumentOutline,
+  FindMatchesCount,
+  FormDataMap,
+  PagesInfo,
+  PresentationMode,
+  ReadAloudState,
+  SidebarViewChange,
+} from "ng2-pdfjs-viewer";
+
+// The viewer outputs this entry reads, typed structurally so it doesn't depend on
+// the component class. PdfJsViewerComponent satisfies this shape. (ChangedPage and
+// ChangedScale are both `number`.)
+export interface PdfViewerSignalSource {
+  onPageChange: EventEmitter<number>;
+  onScaleChange: EventEmitter<number>;
+  onRotationChange: EventEmitter<ChangedRotation>;
+  onPagesInit: EventEmitter<PagesInfo>;
+  onDocumentError: EventEmitter<DocumentError>;
+  onUpdateFindMatchesCount: EventEmitter<FindMatchesCount>;
+  onReadAloudStateChange: EventEmitter<ReadAloudState>;
+  onAnnotationEditorStateChange: EventEmitter<AnnotationEditorState>;
+  annotationEditorChange: EventEmitter<AnnotationEditorMode>;
+  onSidebarViewChanged: EventEmitter<SidebarViewChange>;
+  onMetadataLoaded: EventEmitter<DocumentMetadata>;
+  onOutlineLoaded: EventEmitter<DocumentOutline>;
+  formDataChange: EventEmitter<FormDataMap>;
+  onPresentationModeChanged: EventEmitter<PresentationMode>;
+  zoomChange: EventEmitter<string>;
+  cursorChange: EventEmitter<string>;
+  scrollChange: EventEmitter<string>;
+  spreadChange: EventEmitter<string>;
+  pageModeChange: EventEmitter<string>;
+}
+
+// The read-only signal surface returned by pdfViewerSignals().
+export interface PdfViewerSignals {
+  /** Current 1-based page number; undefined until the first page change. */
+  page: Signal<number | undefined>;
+  /** Current zoom scale factor (1 = 100%); undefined until the first scale change. */
+  scale: Signal<number | undefined>;
+  /** Total page count, available once the document's pages initialize. */
+  totalPages: Signal<number | undefined>;
+  /** True once the document's pages have initialized. */
+  loaded: Signal<boolean>;
+  /** Last document-load error, or undefined if none. */
+  error: Signal<DocumentError | undefined>;
+  /** Page rotation state ({ rotation, page }). */
+  rotation: Signal<ChangedRotation | undefined>;
+  /** Live find/search match counts ({ current, total }). */
+  findMatches: Signal<FindMatchesCount | undefined>;
+  /** Read-aloud progress ({ status, page, sentence? }). */
+  readAloud: Signal<ReadAloudState | undefined>;
+  /** Annotation editor undo/empty/selection state. */
+  annotationEditor: Signal<AnnotationEditorState | undefined>;
+  /** Active annotation editor tool (highlight / ink / freetext / ...). */
+  annotationEditorMode: Signal<AnnotationEditorMode | undefined>;
+  /** Current sidebar panel ({ view }). */
+  sidebar: Signal<SidebarViewChange | undefined>;
+  /** Document metadata (title / author / ...). */
+  metadata: Signal<DocumentMetadata | undefined>;
+  /** Document outline / bookmarks ({ items?, hasOutline }). */
+  outline: Signal<DocumentOutline | undefined>;
+  /** Current AcroForm field values. */
+  formData: Signal<FormDataMap | undefined>;
+  /** Presentation (fullscreen) mode ({ active }). */
+  presentationMode: Signal<PresentationMode | undefined>;
+  /** Zoom mode string (e.g. 'auto', 'page-fit', '125'). */
+  zoom: Signal<string | undefined>;
+  /** Cursor tool ('select' | 'hand'). */
+  cursor: Signal<string | undefined>;
+  /** Scroll mode ('vertical' | 'horizontal' | 'wrapped' | 'page'). */
+  scroll: Signal<string | undefined>;
+  /** Spread mode ('none' | 'odd' | 'even'). */
+  spread: Signal<string | undefined>;
+  /** Page (view) mode. */
+  pageMode: Signal<string | undefined>;
+}
+
+/**
+ * Project the viewer's outputs into read-only signals. See the file header for
+ * usage and the injection-context rules. The returned signals are live: each
+ * updates when its source output next fires.
+ */
+export function pdfViewerSignals(
+  viewer: PdfViewerSignalSource,
+  options: { injector?: Injector } = {},
+): PdfViewerSignals {
+  const { injector } = options;
+  const latest = <T>(source: EventEmitter<T>): Signal<T | undefined> =>
+    toSignal(source, { initialValue: undefined, injector });
+
+  const pages = latest(viewer.onPagesInit);
+  return {
+    page: latest(viewer.onPageChange),
+    scale: latest(viewer.onScaleChange),
+    totalPages: computed(() => pages()?.pagesCount),
+    loaded: computed(() => pages() !== undefined),
+    error: latest(viewer.onDocumentError),
+    rotation: latest(viewer.onRotationChange),
+    findMatches: latest(viewer.onUpdateFindMatchesCount),
+    readAloud: latest(viewer.onReadAloudStateChange),
+    annotationEditor: latest(viewer.onAnnotationEditorStateChange),
+    annotationEditorMode: latest(viewer.annotationEditorChange),
+    sidebar: latest(viewer.onSidebarViewChanged),
+    metadata: latest(viewer.onMetadataLoaded),
+    outline: latest(viewer.onOutlineLoaded),
+    formData: latest(viewer.formDataChange),
+    presentationMode: latest(viewer.onPresentationModeChanged),
+    zoom: latest(viewer.zoomChange),
+    cursor: latest(viewer.cursorChange),
+    scroll: latest(viewer.scrollChange),
+    spread: latest(viewer.spreadChange),
+    pageMode: latest(viewer.pageModeChange),
+  };
+}

--- a/lib/signals/ng-package.json
+++ b/lib/signals/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "./index.ts"
+  }
+}

--- a/lib/tests/pdf-viewer-signals.spec.ts
+++ b/lib/tests/pdf-viewer-signals.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { DestroyRef, EventEmitter, Injector } from "@angular/core";
+import { pdfViewerSignals, PdfViewerSignalSource } from "../signals";
+
+// toSignal() needs a DestroyRef to tear down its subscription. In a real app that
+// comes from the host component's injection context; here we hand it a stub so the
+// projection can be exercised without TestBed/zone (matching this suite's style).
+function makeInjector(): Injector {
+  return Injector.create({
+    providers: [{ provide: DestroyRef, useValue: { onDestroy: () => () => {} } }],
+  });
+}
+
+function makeViewer(): PdfViewerSignalSource {
+  return {
+    onPageChange: new EventEmitter<number>(),
+    onScaleChange: new EventEmitter<number>(),
+    onRotationChange: new EventEmitter(),
+    onPagesInit: new EventEmitter(),
+    onDocumentError: new EventEmitter(),
+    onUpdateFindMatchesCount: new EventEmitter(),
+    onReadAloudStateChange: new EventEmitter(),
+    onAnnotationEditorStateChange: new EventEmitter(),
+    annotationEditorChange: new EventEmitter(),
+    onSidebarViewChanged: new EventEmitter(),
+    onMetadataLoaded: new EventEmitter(),
+    onOutlineLoaded: new EventEmitter(),
+    formDataChange: new EventEmitter(),
+    onPresentationModeChanged: new EventEmitter(),
+    zoomChange: new EventEmitter<string>(),
+    cursorChange: new EventEmitter<string>(),
+    scrollChange: new EventEmitter<string>(),
+    spreadChange: new EventEmitter<string>(),
+    pageModeChange: new EventEmitter<string>(),
+  };
+}
+
+describe("pdfViewerSignals", () => {
+  it("starts empty: value signals are undefined and loaded is false", () => {
+    const viewer = makeViewer();
+    const s = pdfViewerSignals(viewer, { injector: makeInjector() });
+
+    expect(s.page()).toBeUndefined();
+    expect(s.scale()).toBeUndefined();
+    expect(s.totalPages()).toBeUndefined();
+    expect(s.findMatches()).toBeUndefined();
+    expect(s.loaded()).toBe(false);
+  });
+
+  it("reflects the latest value from each source output", () => {
+    const viewer = makeViewer();
+    const s = pdfViewerSignals(viewer, { injector: makeInjector() });
+
+    viewer.onPageChange.emit(3);
+    viewer.onScaleChange.emit(1.25);
+    viewer.zoomChange.emit("page-fit");
+    viewer.onUpdateFindMatchesCount.emit({ current: 2, total: 9 });
+
+    expect(s.page()).toBe(3);
+    expect(s.scale()).toBe(1.25);
+    expect(s.zoom()).toBe("page-fit");
+    expect(s.findMatches()).toEqual({ current: 2, total: 9 });
+
+    // A second emission replaces the value (signals hold the latest, not a stream).
+    viewer.onPageChange.emit(4);
+    expect(s.page()).toBe(4);
+  });
+
+  it("derives totalPages and loaded from page initialization", () => {
+    const viewer = makeViewer();
+    const s = pdfViewerSignals(viewer, { injector: makeInjector() });
+
+    expect(s.loaded()).toBe(false);
+    expect(s.totalPages()).toBeUndefined();
+
+    viewer.onPagesInit.emit({ pagesCount: 14 });
+
+    expect(s.totalPages()).toBe(14);
+    expect(s.loaded()).toBe(true);
+  });
+
+  it("exposes structured payloads as-is", () => {
+    const viewer = makeViewer();
+    const s = pdfViewerSignals(viewer, { injector: makeInjector() });
+
+    viewer.onReadAloudStateChange.emit({ status: "reading", page: 2, sentence: "Hi." });
+    viewer.onSidebarViewChanged.emit({ view: "thumbs" });
+    viewer.annotationEditorChange.emit("highlight");
+
+    expect(s.readAloud()).toEqual({ status: "reading", page: 2, sentence: "Hi." });
+    expect(s.sidebar()).toEqual({ view: "thumbs" });
+    expect(s.annotationEditorMode()).toBe("highlight");
+  });
+});


### PR DESCRIPTION
A new secondary entry point, `ng2-pdfjs-viewer/signals`, that projects the component's `@Output()` events into read-only Angular signals for zoneless / OnPush apps.

```ts
import { pdfViewerSignals } from 'ng2-pdfjs-viewer/signals';

ngAfterViewInit() {
  this.signals = pdfViewerSignals(this.viewer, { injector: this.injector });
}
// template: {{ signals.page() }} / {{ signals.totalPages() }} / {{ signals.loaded() }}
```

### What you get
20 read-only signals: `page`, `scale`, `totalPages`, `loaded`, `error`, `rotation`, `findMatches`, `readAloud`, `annotationEditor`, `annotationEditorMode`, `sidebar`, `metadata`, `outline`, `formData`, `presentationMode`, and the `zoom`/`cursor`/`scroll`/`spread`/`pageMode` strings. Each holds the latest value from its source output; `loaded`/`totalPages` derive from page initialization. `computed`/`effect` compose on top with no manual change detection.

### Design
- **Self-contained, like `ng2-pdfjs-viewer/ai`.** Uses only `@angular/core` and `@angular/core/rxjs-interop`, so the base package keeps its `>=10` peer range. This entry point requires **Angular 16+** and is imported from the subpath, so older apps never load it.
- **`{ injector }` option** because a `@ViewChild` is only ready in `ngAfterViewInit`, which is not an injection context. Subscriptions clean up via the injector's `DestroyRef`.
- **Read-only.** It projects existing outputs and adds no viewer behaviour; the outputs still work for anyone who prefers `(event)` bindings.

### Tests / docs
- 4 new specs (empty-start, live updates, `totalPages`/`loaded` derivation, structured payloads); 64 total pass.
- ng-packagr build verified — all three entry points (`ai`, primary, `signals`) compile; `exports["./signals"]` + FESM + `.d.ts` emitted.
- New feature doc, overview row, sidebar entry, and a CHANGELOG (Unreleased) note covering this and the existing AI streaming addition.

No `lib/package.json` dependency changes. Ships to consumers on the next npm release.