### PR TITLE
Release 26.2.0: signals + AI streaming entry points; fix onPagesInit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [26.2.0] - 2026-06-27
 
 ### Added
 - `ng2-pdfjs-viewer/signals`: a new entry point that projects viewer state — current

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   falling back to a single response when the endpoint doesn't stream. The built-in
   chat panel renders the answer as it arrives.
 
+### Fixed
+- `onPagesInit` now fires once the document's pages initialize - it carries the
+  page count and was declared but never emitted. This is what makes the new
+  signals entry point's `loaded()` and `totalPages()` populate.
+
 ## [26.1.1] - 2026-06-23
 
 ### Changed

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ng2-pdfjs-viewer",
-  "version": "26.1.1",
+  "version": "26.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ng2-pdfjs-viewer",
-      "version": "26.1.1",
+      "version": "26.2.0",
       "license": "Apache-2.0 (Commons Clause)",
       "devDependencies": {
         "@angular/compiler-cli": "^22.0.0",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-pdfjs-viewer",
-  "version": "26.1.1",
+  "version": "26.2.0",
   "description": "The most comprehensive Angular PDF viewer, powered by Mozilla PDF.js 6 — view, annotate, sign, fill forms, search, and read aloud from one component. 8.3M+ downloads, mobile-first, production-ready.",
   "author": {
     "name": "Aneesh Goapalakrishnan",

--- a/lib/src/ng2-pdfjs-viewer.component.ts
+++ b/lib/src/ng2-pdfjs-viewer.component.ts
@@ -2323,6 +2323,19 @@ export class PdfJsViewerComponent
               console.debug("PdfJsViewer: The document has now been loaded!");
             this.onDocumentLoad.emit();
 
+            // Project onPagesInit here. PDF.js fires the real 'pagesinit' once,
+            // BEFORE this handler map finishes registering (it lands between
+            // 'pagesinit' and 'scalechanging'), and the postMessage wrapper's own
+            // pagesInit relay is wired on 'documentloaded' too late for the
+            // one-shot - so onPagesInit never fired and the signals entry point's
+            // loaded()/totalPages() stayed empty. 'documentloaded' is reliably
+            // caught (it drives onDocumentLoad) and pagesCount is set by now.
+            const app = this.PDFViewerApplication;
+            const pagesCount = app?.pagesCount ?? app?.pdfDocument?.numPages;
+            if (typeof pagesCount === "number" && pagesCount > 0) {
+              this.onPagesInit.emit({ pagesCount });
+            }
+
             // Queue auto-actions with the property values current at THIS load
             this.queueAutoActionsForDocumentLoad();
 


### PR DESCRIPTION
Cuts 26.2.0.

- Bumps the version 26.1.1 to 26.2.0 (package.json + lockfile) and promotes the CHANGELOG Unreleased section.
- Releases the two lib features already merged to master: the `ng2-pdfjs-viewer/signals` read-only signals entry point, and AI assistant token streaming.
- Fixes `onPagesInit`: it was declared but never emitted, so the signals `loaded()` and `totalPages()` stayed empty. It now fires from the `documentloaded` eventBus handler carrying the page count.

Verified end to end against the playground: `loaded()`, `totalPages()`, `page()`, `scale()` and `rotation()` all update live, and the lib unit suite passes (64/64).
