### PR TITLE
Playground: add a Signals demo page

### DIFF
--- a/playground/src/app/core/feature-registry.ts
+++ b/playground/src/app/core/feature-registry.ts
@@ -123,6 +123,12 @@ export const FEATURES: FeaturePage[] = [
     load: () => import('../pages/api/api.component').then((m) => m.ApiComponent),
   },
   {
+    id: 'signals', route: 'signals', title: 'Signals (zoneless / OnPush)', group: 'Integration', icon: '∿', badge: 'new',
+    description: 'Read viewer state as read-only Angular signals — page, zoom, totals, search matches — for zoneless and OnPush apps.',
+    tags: ['signals', 'pdfViewerSignals', 'zoneless', 'OnPush', 'computed', 'toSignal'],
+    load: () => import('../pages/signals/signals.component').then((m) => m.SignalsComponent),
+  },
+  {
     id: 'custom-ui', route: 'custom-ui', title: 'Custom Toolbar & Overlays', group: 'Viewer UI', icon: '⊞', badge: 'new',
     description: 'Replace the toolbar with your own Angular template and project templates onto every page.',
     tags: ['customToolbarTpl', 'pageOverlayTpl', 'showToolbar', 'headless'],

--- a/playground/src/app/pages/signals/signals.component.html
+++ b/playground/src/app/pages/signals/signals.component.html
@@ -1,0 +1,39 @@
+<pg-page
+  title="Signals (zoneless / OnPush)"
+  lead="Read viewer state as read-only Angular signals from the ng2-pdfjs-viewer/signals entry point — no (event) bindings, no markForCheck. Page through the document or use the toolbar (zoom, search, rotate, sidebar) and watch the inspector update straight from the signals."
+  [tags]="['signals','pdfViewerSignals','zoneless','OnPush','computed']"
+  [code]="code()"
+  docHref="https://angularpdf.com/docs/features/signals">
+
+  <div preview>
+    <ng2-pdfjs-viewer #viewer
+      [pdfSrc]="src()"
+      [theme]="theme.mode()"
+      [page]="page()">
+    </ng2-pdfjs-viewer>
+  </div>
+
+  <div controls>
+    <div class="ph">Drive the viewer</div>
+    <div class="row">
+      <span>Page (input)</span>
+      <span class="seg">
+        <button type="button" (click)="go(-1)">‹ Prev</button>
+        <button type="button" data-testid="page-input">{{ page() }}</button>
+        <button type="button" (click)="go(1)">Next ›</button>
+      </span>
+    </div>
+
+    <div class="ph">Derived (computed)</div>
+    <div class="summary" data-testid="match-summary">{{ matchSummary() }}</div>
+
+    <div class="ph">Live signals inspector</div>
+    <table class="inspect">
+      <tbody>
+        @for (r of rows(); track r.k) {
+          <tr><td>{{ r.k }}</td><td [attr.data-signal]="r.k">{{ r.v }}</td></tr>
+        }
+      </tbody>
+    </table>
+  </div>
+</pg-page>

--- a/playground/src/app/pages/signals/signals.component.scss
+++ b/playground/src/app/pages/signals/signals.component.scss
@@ -1,0 +1,6 @@
+.inspect { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+.inspect td { padding: 7px 0; border-bottom: 1px dashed var(--border); }
+.inspect td:first-child { color: var(--faint); font-family: var(--mono); font-size: 11.5px; }
+.inspect td:last-child { text-align: right; color: var(--ink); font-family: var(--mono); }
+
+.summary { font-size: 12.5px; color: var(--ink); font-family: var(--mono); padding: 2px 0 4px; }

--- a/playground/src/app/pages/signals/signals.component.ts
+++ b/playground/src/app/pages/signals/signals.component.ts
@@ -1,0 +1,90 @@
+import { AfterViewInit, Component, Injector, ViewChild, computed, inject, signal } from '@angular/core';
+import { PdfJsViewerComponent, PdfJsViewerModule } from 'ng2-pdfjs-viewer';
+import { pdfViewerSignals, PdfViewerSignals } from 'ng2-pdfjs-viewer/signals';
+import { SamplePdfService } from '../../core/services/sample-pdf.service';
+import { ThemeService } from '../../core/services/theme.service';
+import { PlaygroundLayoutComponent } from '../../shared/playground-layout.component';
+
+const fmt = (v: unknown): string => (v === undefined || v === null ? '—' : String(v));
+
+@Component({
+  selector: 'pg-signals',
+  standalone: true,
+  imports: [PlaygroundLayoutComponent, PdfJsViewerModule],
+  templateUrl: './signals.component.html',
+  styleUrl: './signals.component.scss',
+})
+export class SignalsComponent implements AfterViewInit {
+  private readonly samples = inject(SamplePdfService);
+  readonly theme = inject(ThemeService);
+  private readonly injector = inject(Injector);
+  readonly src = computed(() => this.samples.current().src);
+
+  // We drive the page imperatively; the inspector reads it back from the SIGNAL,
+  // so you can see the projection update independently of the input we set.
+  readonly page = signal(1);
+
+  @ViewChild('viewer') viewer!: PdfJsViewerComponent;
+
+  // Held in a signal (not a plain field) so the computeds below take a dependency
+  // on it — otherwise `this.sig?.page()` short-circuits before reading any signal
+  // and the rows never refresh once the bundle is wired up in ngAfterViewInit.
+  readonly sig = signal<PdfViewerSignals | undefined>(undefined);
+
+  ngAfterViewInit(): void {
+    this.sig.set(pdfViewerSignals(this.viewer, { injector: this.injector }));
+  }
+
+  go(delta: number): void { this.page.set(Math.max(1, this.page() + delta)); }
+
+  // Live inspector — each row reads a signal, so the table re-renders on its own
+  // whenever the viewer emits (no markForCheck, no event bindings).
+  readonly rows = computed(() => {
+    const s = this.sig();
+    if (!s) return [{ k: 'loaded()', v: 'false' }];
+    const scale = s.scale();
+    const m = s.findMatches();
+    return [
+      { k: 'loaded()', v: String(s.loaded()) },
+      { k: 'page()', v: fmt(s.page()) },
+      { k: 'totalPages()', v: fmt(s.totalPages()) },
+      { k: 'scale()', v: scale != null ? Math.round(scale * 100) + '%' : '—' },
+      { k: 'rotation()', v: fmt(s.rotation()?.rotation) },
+      { k: 'findMatches()', v: m ? `${m.current} / ${m.total}` : '—' },
+      { k: 'readAloud()', v: fmt(s.readAloud()?.status) },
+      { k: 'sidebar()', v: fmt(s.sidebar()?.view) },
+    ];
+  });
+
+  // A derived label that recomputes only when search state changes — the kind of
+  // thing `computed` makes trivial on top of the raw signals.
+  readonly matchSummary = computed(() => {
+    const m = this.sig()?.findMatches();
+    return m ? `${m.current} of ${m.total} matches` : 'No active search';
+  });
+
+  readonly code = computed(() =>
+    [
+      `import { pdfViewerSignals, PdfViewerSignals } from 'ng2-pdfjs-viewer/signals';`,
+      ``,
+      `@ViewChild('viewer') viewer!: PdfJsViewerComponent;`,
+      `private injector = inject(Injector);`,
+      `signals!: PdfViewerSignals;`,
+      ``,
+      `ngAfterViewInit() {`,
+      `  // @ViewChild is set here but this isn't an injection context,`,
+      `  // so hand toSignal an Injector captured earlier.`,
+      `  this.signals = pdfViewerSignals(this.viewer, { injector: this.injector });`,
+      `}`,
+      ``,
+      `// template: {{ signals.page() }} of {{ signals.totalPages() }}`,
+      `//           {{ signals.scale() | percent }}`,
+      ``,
+      `// compose with computed — no manual change detection`,
+      `readonly matchSummary = computed(() => {`,
+      `  const m = this.signals.findMatches();`,
+      `  return m ? \`\${m.current} of \${m.total}\` : 'No search';`,
+      `});`,
+    ].join('\n'),
+  );
+}


### PR DESCRIPTION
Adds a **Signals** explorer page to the playground: a live inspector that reads `loaded()`, `page()`, `totalPages()`, `scale()`, `rotation()`, `findMatches()` and more straight from `pdfViewerSignals(viewer, { injector })`, plus a `computed` derived label.

Verified end to end with a browser session: the signals update live as you page through the document, zoom, and rotate.

> Depends on **26.2.0** being on npm first — the playground builds against the published package (`^26.0.0` floats up to 26.2.0), and the page imports `ng2-pdfjs-viewer/signals`. Merge after the 26.2.0 publish completes; the Vercel preview will be red until then.
