### PR TITLE
Playground: require ng2-pdfjs-viewer ^26.2.0 (signals entry point)

### DIFF
--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -15,7 +15,7 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/router": "^22.0.0",
         "@stackblitz/sdk": "^1.11.0",
-        "ng2-pdfjs-viewer": "^26.0.0",
+        "ng2-pdfjs-viewer": "^26.2.0",
         "rxjs": "^7.8.1",
         "tslib": "^2.6.0",
         "zone.js": "~0.15.0"
@@ -13271,10 +13271,10 @@
       }
     },
     "node_modules/ng2-pdfjs-viewer": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/ng2-pdfjs-viewer/-/ng2-pdfjs-viewer-26.1.0.tgz",
-      "integrity": "sha512-P8sJquXnQxMkt72YZCo8PYqlECnXe7iukkZFxvVTYEiZmG+BsytqXCmIKYL7GrSh5mmGdKMKMoBLNmvBm70kow==",
-      "license": "Apache-2.0 + Commons Clause",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/ng2-pdfjs-viewer/-/ng2-pdfjs-viewer-26.2.0.tgz",
+      "integrity": "sha512-tJ1e1xyH3VvDy1E8x/HtaSAbY6PBFKNvDz+w4bxKxckFqn3P7WM90XxWVi6Uq2wzqKkS75vnTMwWC2G6Icg4KA==",
+      "license": "Apache-2.0 (Commons Clause)",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/playground/package.json
+++ b/playground/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser": "^22.0.0",
     "@angular/router": "^22.0.0",
     "@stackblitz/sdk": "^1.11.0",
-    "ng2-pdfjs-viewer": "^26.0.0",
+    "ng2-pdfjs-viewer": "^26.2.0",
     "rxjs": "^7.8.1",
     "tslib": "^2.6.0",
     "zone.js": "~0.15.0"


### PR DESCRIPTION
The playground now imports `ng2-pdfjs-viewer/signals`, which exists from 26.2.0. The dependency was `^26.0.0`, which can resolve to a cached 26.1.x without the signals subpath and fail the build. Pins to `^26.2.0` and updates the lockfile (only the ng2-pdfjs-viewer entry changes). Verified with a clean production build against the published 26.2.0.