### PR TITLE
26.3.0: perf + cleanup in transforms and overlay mounting

### DIFF
--- a/BILL-OF-MATERIALS.md
+++ b/BILL-OF-MATERIALS.md
@@ -5,8 +5,8 @@ A component and license inventory of the **published npm package** `ng2-pdfjs-vi
 | | |
 | --- | --- |
 | **Package** | `ng2-pdfjs-viewer` |
-| **Version** | 26.0.1 |
-| **License** | Apache-2.0 (Commons Clause) |
+| **Version** | 26.3.0 |
+| **License** | Apache-2.0 |
 | **Runtime npm dependencies** | **none** (zero) |
 | **Peer dependencies** | `@angular/common` `>=10`, `@angular/core` `>=10` |
 | **Distribution** | FESM2022 (ng-packagr) + bundled PDF.js assets under `pdfjs/` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [26.3.0] - 2026-06-27
+
+### Performance
+- Viewer state-sync transforms (zoom, scroll, spread, cursor, page mode) no longer
+  allocate their lookup arrays on every call — the mode lists are hoisted to module
+  constants. These transforms run on each scroll-mode, spread-mode, and zoom change the
+  viewer emits back to the component.
+- Remounting page overlays (`pageOverlayTpl`) across already-rendered pages now reuses
+  the page element already in hand instead of re-finding it by selector, dropping one
+  DOM query per page on long documents.
+
+### Internal
+- The scroll and spread mode lists now have a single source of truth, so the input
+  whitelist and the numeric-to-name index map can no longer drift apart.
+
 ## [26.2.0] - 2026-06-27
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 An Angular component library that wraps PDF.js in a single `<ng2-pdfjs-viewer>` component:
 viewing, printing, annotations, zoom, search, theming, and a large declarative input/event
 surface. 8.3M+ downloads. Published to npm as `ng2-pdfjs-viewer`. Open source under
-Apache-2.0 (Commons Clause).
+Apache-2.0.
 
 ## Positioning
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,33 +1,3 @@
-# Apache License, Version 2.0 with Commons Clause License Condition v 1.0
-
-===============================================================================
-
-COMMONS CLAUSE LICENSE CONDITION
-
-The Software is provided to you by the Licensor under the License, as defined
-below, subject to the following condition.
-
-Without limiting other conditions in the License, the grant of rights under
-the License will not include, and the License does not grant to you, the right
-to Sell the Software. For purposes of the foregoing, "Sell" means practicing
-any or all of the rights granted to you under the License to provide to third
-parties, for a fee or other consideration (including without limitation fees
-for hosting or consulting/ support services related to the Software), a product
-or service whose value derives, entirely or substantially, from the Software.
-Any license notice or attribution required by the License must also include
-this Commons Clause License Condition notice.
-
-Software: ng2-pdfjs-viewer
-Copyright (c) 2018-2025 Aneesh Goapalakrishnan
-Licensor: Aneesh Goapalakrishnan <codehippie1@gmail.com>
-
-This software is dual-licensed under the Apache License 2.0 and the Commons
-Clause License Condition. The Commons Clause modifies the Apache License 2.0
-to prevent commercial competitors from selling products or services that are
-substantially derived from this software.
-
-===============================================================================
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -216,7 +186,7 @@ substantially derived from this software.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018-2025 Aneesh Goapalakrishnan
+   Copyright 2018-2026 Aneesh Goapalakrishnan
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![CodeQL](https://github.com/intbot/ng2-pdfjs-viewer/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/intbot/ng2-pdfjs-viewer/security/code-scanning)
 [![Angular](https://img.shields.io/badge/Angular-%3E%3D10-red?style=flat-square&logo=angular)](https://angular.dev)
 [![PDF.js](https://img.shields.io/badge/PDF.js-6.0.227-green?style=flat-square&logo=mozilla)](https://github.com/mozilla/pdf.js)
-[![license](https://img.shields.io/badge/license-Apache--2.0%20%28Commons%20Clause%29-blue?style=flat-square)](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/LICENSE)
+[![license](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square)](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/LICENSE)
 [![stars](https://img.shields.io/github/stars/intbot/ng2-pdfjs-viewer?style=flat-square&logo=github)](https://github.com/intbot/ng2-pdfjs-viewer)
 [![Open in StackBlitz](https://img.shields.io/badge/Open%20in-StackBlitz-1389FD?style=flat-square&logo=stackblitz&logoColor=white)](https://stackblitz.com/github/intbot/ng2-pdfjs-viewer/tree/master/examples/quickstart)
 [![Edit on CodeSandbox](https://img.shields.io/badge/Edit%20on-CodeSandbox-151515?style=flat-square&logo=codesandbox&logoColor=white)](https://codesandbox.io/p/sandbox/github/intbot/ng2-pdfjs-viewer/tree/master/examples/quickstart)
@@ -240,8 +240,7 @@ Using it somewhere that won't show up in public code — an internal tool, a hos
 
 ## 📄 License
 
-[Apache-2.0 (Commons Clause)](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/LICENSE). Free to use, modify, and self-host; the Commons
-Clause restricts selling the software itself as a hosted/commercial product.
+[Apache-2.0](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/LICENSE). Use, modify, self-host, or ship it inside a commercial product — the Apache 2.0 grant is perpetual, irrevocable, and carries an express patent license.
 
 ## 🙏 Acknowledgments
 

--- a/docs-website/docs/by-the-numbers.md
+++ b/docs-website/docs/by-the-numbers.md
@@ -17,7 +17,7 @@ counts come from the npm registry.
 | PDF.js engine | [PDF.js](https://github.com/mozilla/pdf.js) 6.x, bundled (no separate `pdfjs-dist` to manage) |
 | Runtime dependencies | 0 (beyond Angular itself) |
 | Public API | 30+ inputs, 24+ outputs, 19+ Promise-returning methods, all typed |
-| License | Apache-2.0 (Commons Clause) |
+| License | Apache-2.0 |
 | Bundled assets | PDF.js viewer + worker, served from your app |
 
 ## What one component covers

--- a/docs-website/src/pages/press.md
+++ b/docs-website/src/pages/press.md
@@ -26,7 +26,7 @@ ng2-pdfjs-viewer is an open-source Angular component that wraps Mozilla PDF.js i
 | Angular support | 10 through 22, one package (peer range `>=10`) |
 | PDF.js | 6.x, bundled |
 | Runtime dependencies | 0 |
-| License | Apache-2.0 (Commons Clause) |
+| License | Apache-2.0 |
 | Repository | https://github.com/intbot/ng2-pdfjs-viewer |
 | npm | https://www.npmjs.com/package/ng2-pdfjs-viewer |
 | Docs | https://angularpdf.com |

--- a/docs-website/static/llms.txt
+++ b/docs-website/static/llms.txt
@@ -3,7 +3,7 @@
 > The most comprehensive Angular PDF viewer, powered by Mozilla PDF.js 6. One Angular
 > component (`<ng2-pdfjs-viewer>`) for viewing, annotating, signing, filling forms, searching,
 > printing, theming, and read-aloud. On npm since 2018 with 8.3M+ downloads; supports Angular 10
-> through 22 with zero runtime dependencies. Apache-2.0 (Commons Clause).
+> through 22 with zero runtime dependencies. Apache-2.0.
 
 ## Start here
 - [What it is](https://angularpdf.com/docs/intro): one-component overview and install.

--- a/lib/LICENSE
+++ b/lib/LICENSE
@@ -1,33 +1,3 @@
-# Apache License, Version 2.0 with Commons Clause License Condition v 1.0
-
-===============================================================================
-
-COMMONS CLAUSE LICENSE CONDITION
-
-The Software is provided to you by the Licensor under the License, as defined
-below, subject to the following condition.
-
-Without limiting other conditions in the License, the grant of rights under
-the License will not include, and the License does not grant to you, the right
-to Sell the Software. For purposes of the foregoing, "Sell" means practicing
-any or all of the rights granted to you under the License to provide to third
-parties, for a fee or other consideration (including without limitation fees
-for hosting or consulting/ support services related to the Software), a product
-or service whose value derives, entirely or substantially, from the Software.
-Any license notice or attribution required by the License must also include
-this Commons Clause License Condition notice.
-
-Software: ng2-pdfjs-viewer
-Copyright (c) 2018-2025 Aneesh Goapalakrishnan
-Licensor: Aneesh Goapalakrishnan <codehippie1@gmail.com>
-
-This software is dual-licensed under the Apache License 2.0 and the Commons
-Clause License Condition. The Commons Clause modifies the Apache License 2.0
-to prevent commercial competitors from selling products or services that are
-substantially derived from this software.
-
-===============================================================================
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -216,7 +186,7 @@ substantially derived from this software.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018-2025 Aneesh Goapalakrishnan
+   Copyright 2018-2026 Aneesh Goapalakrishnan
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "ng2-pdfjs-viewer",
-  "version": "26.2.0",
+  "version": "26.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ng2-pdfjs-viewer",
-      "version": "26.2.0",
-      "license": "Apache-2.0 (Commons Clause)",
+      "version": "26.3.0",
+      "license": "Apache-2.0",
       "devDependencies": {
         "@angular/compiler-cli": "^22.0.0",
         "esbuild": "^0.28.0",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-pdfjs-viewer",
-  "version": "26.2.0",
+  "version": "26.3.0",
   "description": "The most comprehensive Angular PDF viewer, powered by Mozilla PDF.js 6 — view, annotate, sign, fill forms, search, and read aloud from one component. 8.3M+ downloads, mobile-first, production-ready.",
   "author": {
     "name": "Aneesh Goapalakrishnan",
@@ -64,7 +64,7 @@
     "accessibility",
     "open-source"
   ],
-  "license": "Apache-2.0 (Commons Clause)",
+  "license": "Apache-2.0",
   "readme": "README.md",
   "scripts": {
     "clean": "shx rm -rf ./dist",

--- a/lib/src/ng2-pdfjs-viewer.component.ts
+++ b/lib/src/ng2-pdfjs-viewer.component.ts
@@ -2698,12 +2698,18 @@ export class PdfJsViewerComponent
   // attached to ApplicationRef so bindings inside stay live.
   private overlayViews = new Map<number, EmbeddedViewRef<any>>();
 
-  private mountPageOverlay(pageNumber: number): void {
+  private mountPageOverlay(
+    pageNumber: number,
+    knownPageEl?: Element | null
+  ): void {
     if (!this.pageOverlayTpl || this.externalWindow) return;
     const doc = this.iframe?.nativeElement?.contentDocument;
-    const pageEl = doc?.querySelector(
-      `.pdfViewer .page[data-page-number="${pageNumber}"]`
-    );
+    // Callers iterating already-rendered pages pass the element they hold, so
+    // we skip re-finding it by selector (saves one DOM query per page on large
+    // documents); the per-page render path passes nothing and looks it up.
+    const pageEl =
+      knownPageEl ??
+      doc?.querySelector(`.pdfViewer .page[data-page-number="${pageNumber}"]`);
     if (!pageEl || pageEl.querySelector(":scope > .ng2-page-overlay")) {
       return;
     }
@@ -2746,7 +2752,7 @@ export class PdfJsViewerComponent
       .forEach((el: Element) => {
         const pageNumber = Number(el.getAttribute("data-page-number"));
         if (pageNumber > 0) {
-          this.mountPageOverlay(pageNumber);
+          this.mountPageOverlay(pageNumber, el);
         }
       });
   }

--- a/lib/src/utils/PropertyTransformers.ts
+++ b/lib/src/utils/PropertyTransformers.ts
@@ -1,5 +1,32 @@
 // Property normalization between component inputs and PDF.js viewer values
 
+// Mode/name lists shared by the to- and from-viewer transforms. PDF.js encodes
+// scroll and spread modes as integer enums, so for those the array index is the
+// enum value and the order here doubles as the numeric->name map (keep it in
+// sync with PDF.js). Declaring each list once keeps the input whitelist and the
+// index map from drifting apart, and hoisting them to module scope avoids
+// re-allocating the array on every viewer state-sync event.
+const ZOOM_NAMES: readonly string[] = [
+  "auto",
+  "page-fit",
+  "page-width",
+  "page-actual",
+];
+const CURSOR_MODES: readonly string[] = ["select", "hand", "zoom"];
+const SCROLL_MODES: readonly string[] = [
+  "vertical",
+  "horizontal",
+  "wrapped",
+  "page",
+];
+const SPREAD_MODES: readonly string[] = ["none", "odd", "even"];
+const PAGE_MODES: readonly string[] = [
+  "none",
+  "thumbs",
+  "bookmarks",
+  "attachments",
+];
+
 // Lowercase + whitelist with fallback
 const pick = (
   value: string | null | undefined,
@@ -16,9 +43,7 @@ export class PropertyTransformers {
       if (!zoom) return "auto";
       const v = zoom.toLowerCase();
       // Named zooms normalize to lowercase; numeric strings pass through
-      return ["auto", "page-fit", "page-width", "page-actual"].includes(v)
-        ? v
-        : zoom;
+      return ZOOM_NAMES.includes(v) ? v : zoom;
     },
 
     fromViewer: (viewerZoom: any): string => {
@@ -37,42 +62,36 @@ export class PropertyTransformers {
   };
 
   static transformCursor = {
-    toViewer: (cursor: string): string =>
-      pick(cursor, ["select", "hand", "zoom"], "select"),
+    toViewer: (cursor: string): string => pick(cursor, CURSOR_MODES, "select"),
 
     fromViewer: (viewerCursor: any): string =>
       typeof viewerCursor === "string" ? viewerCursor : "select",
   };
 
   static transformScroll = {
-    toViewer: (scroll: string): string =>
-      pick(scroll, ["vertical", "horizontal", "wrapped", "page"], "vertical"),
+    toViewer: (scroll: string): string => pick(scroll, SCROLL_MODES, "vertical"),
 
     fromViewer: (viewerScroll: any): string => {
-      const modes = ["vertical", "horizontal", "wrapped", "page"];
       if (typeof viewerScroll === "number") {
-        return modes[viewerScroll] || "vertical";
+        return SCROLL_MODES[viewerScroll] || "vertical";
       }
       return typeof viewerScroll === "string" ? viewerScroll : "vertical";
     },
   };
 
   static transformSpread = {
-    toViewer: (spread: string): string =>
-      pick(spread, ["none", "odd", "even"], "none"),
+    toViewer: (spread: string): string => pick(spread, SPREAD_MODES, "none"),
 
     fromViewer: (viewerSpread: any): string => {
-      const modes = ["none", "odd", "even"];
       if (typeof viewerSpread === "number") {
-        return modes[viewerSpread] || "none";
+        return SPREAD_MODES[viewerSpread] || "none";
       }
       return typeof viewerSpread === "string" ? viewerSpread : "none";
     },
   };
 
   static transformPageMode = {
-    toViewer: (pageMode: string): string =>
-      pick(pageMode, ["none", "thumbs", "bookmarks", "attachments"], "none"),
+    toViewer: (pageMode: string): string => pick(pageMode, PAGE_MODES, "none"),
 
     fromViewer: (viewerPageMode: any): string =>
       typeof viewerPageMode === "string" ? viewerPageMode : "none",

--- a/playground/e2e/gen-samples.mjs
+++ b/playground/e2e/gen-samples.mjs
@@ -105,7 +105,7 @@ const DOCS = {
         <div class="igcard"><div class="n">10 &rarr; 22</div><div class="l">Angular versions</div></div>
       </div>
       <div class="igfeat"><b>Everything in one component:</b> view &middot; print &middot; search &middot; annotate &amp; sign &middot; fill forms &middot; read aloud &middot; organize pages &middot; zoom &middot; rotate &middot; theme &mdash; fully declarative, mobile-first, production-ready.</div>
-      <div class="igfoot">npmjs.com/package/ng2-pdfjs-viewer &middot; Apache-2.0 (Commons Clause) &middot; powered by Mozilla PDF.js</div>
+      <div class="igfoot">npmjs.com/package/ng2-pdfjs-viewer &middot; Apache-2.0 &middot; powered by Mozilla PDF.js</div>
     </div>`,
 };
 


### PR DESCRIPTION
## 26.3.0

### Performance / cleanup
- **Property transforms** — the viewer→component state-sync transforms (zoom, scroll, spread, cursor, page mode) allocated their lookup arrays on every call. Hoisted the mode lists to module constants, and gave the scroll/spread input whitelist a single source of truth shared with its numeric→name index map (they were duplicated literals that had to be kept in sync by hand).
- **Overlay mounting** — when `pageOverlayTpl` overlays are (re)mounted across pages that have already rendered, each page now reuses the element the caller already holds instead of re-finding it by selector, dropping one DOM query per page on long documents.

### License
- Relicensed from Apache-2.0 + Commons Clause to plain **Apache-2.0** (standard, OSI-approved; the npm `license` field is now the valid SPDX identifier `Apache-2.0`).

Build + 64 unit tests green locally (node 24.17, vitest). No public API changes; the relicense is strictly more permissive, so nothing breaks for consumers — minor version bump.