### PR TITLE
Playground: pin ng2-pdfjs-viewer to ^26.3.0

### DIFF
--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -15,7 +15,7 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/router": "^22.0.0",
         "@stackblitz/sdk": "^1.11.0",
-        "ng2-pdfjs-viewer": "^26.2.0",
+        "ng2-pdfjs-viewer": "^26.3.0",
         "rxjs": "^7.8.1",
         "tslib": "^2.6.0",
         "zone.js": "~0.15.0"
@@ -13271,10 +13271,10 @@
       }
     },
     "node_modules/ng2-pdfjs-viewer": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/ng2-pdfjs-viewer/-/ng2-pdfjs-viewer-26.2.0.tgz",
-      "integrity": "sha512-tJ1e1xyH3VvDy1E8x/HtaSAbY6PBFKNvDz+w4bxKxckFqn3P7WM90XxWVi6Uq2wzqKkS75vnTMwWC2G6Icg4KA==",
-      "license": "Apache-2.0 (Commons Clause)",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/ng2-pdfjs-viewer/-/ng2-pdfjs-viewer-26.3.0.tgz",
+      "integrity": "sha512-FfMwoa5tguhjQPnLFEWY8RoAsGaChscfbc3zKgWewTkgGCY8N9mlP7AFWKPEc4stKc9WGGV9grLyVMR7gGMoWg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/playground/package.json
+++ b/playground/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser": "^22.0.0",
     "@angular/router": "^22.0.0",
     "@stackblitz/sdk": "^1.11.0",
-    "ng2-pdfjs-viewer": "^26.2.0",
+    "ng2-pdfjs-viewer": "^26.3.0",
     "rxjs": "^7.8.1",
     "tslib": "^2.6.0",
     "zone.js": "~0.15.0"


### PR DESCRIPTION
Bumps the demo/playground dependency to the just-published 26.3.0 so demo.angularpdf.com runs the latest release. Only the single lockfile entry changed (version / resolved / integrity / license → `Apache-2.0`); no other dependencies touched, no lib or docs changes.