### PR TITLE
Fix #373: keep the print button hidden after a Blob document loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [26.3.1] - 2026-06-29
+
+### Fixed
+- `[controlVisibility]="{ print: false }"` (and the standalone `[showPrint]="false"`)
+  now keeps the print button hidden after the document loads. PDF.js re-asserts its
+  own `hidden` class on the print button on every load via its `printingallowed`
+  handler, which wiped our hide and brought the icon back — most visibly with a Blob
+  `pdfSrc`, whose fast local load lands after the hide. The viewer now hides buttons
+  with a dedicated class PDF.js never touches, so the choice sticks. Thanks to
+  @leominaudo for the report. (#373)
+
 ## [26.3.0] - 2026-06-27
 
 ### Performance

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ng2-pdfjs-viewer",
-  "version": "26.3.0",
+  "version": "26.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ng2-pdfjs-viewer",
-      "version": "26.3.0",
+      "version": "26.3.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@angular/compiler-cli": "^22.0.0",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-pdfjs-viewer",
-  "version": "26.3.0",
+  "version": "26.3.1",
   "description": "The most comprehensive Angular PDF viewer, powered by Mozilla PDF.js 6 — view, annotate, sign, fill forms, search, and read aloud from one component. 8.3M+ downloads, mobile-first, production-ready.",
   "author": {
     "name": "Aneesh Goapalakrishnan",

--- a/lib/pdfjs/web/ng2-customization.css
+++ b/lib/pdfjs/web/ng2-customization.css
@@ -110,6 +110,14 @@ body #outerContainer.sidebar-right.viewsManagerOpen #loadingBar {
   pointer-events: none !important;
 }
 
+/* A toolbar button forced hidden by [controlVisibility]. Uses our own class,
+   not PDF.js's `hidden`, so that PDF.js re-asserting `hidden` on document load
+   (the print button via its `printingallowed` handler - Issue #373, seen with
+   fast Blob loads) can't bring a hidden button back. */
+.ng2-btn-hidden {
+  display: none !important;
+}
+
 /* Whole toolbar hidden (custom host toolbars) - viewer reclaims the height */
 #outerContainer.ng2-toolbar-hidden #toolbarContainer {
   display: none !important;

--- a/lib/pdfjs/web/postmessage-wrapper.js
+++ b/lib/pdfjs/web/postmessage-wrapper.js
@@ -207,12 +207,22 @@
     diagnosticLogs = enabled;
   }
 
-  // Button visibility control helper (consolidated from separate module)
+  // Button visibility control helper (consolidated from separate module).
+  // Toggle PDF.js's own `hidden` (so a button PDF.js hides by default, e.g.
+  // openFile, is revealed on show) AND our `ng2-btn-hidden`. The latter is what
+  // makes a HIDE stick: PDF.js re-asserts `hidden` on the print button on every
+  // document load via its `printingallowed` handler, which would otherwise wipe
+  // our hide and bring the button back (Issue #373, deterministic with the fast
+  // local load of a Blob source). `ng2-btn-hidden` (display:none !important) is
+  // never touched by PDF.js, so the consumer's choice survives.
   function toggleButtonVisibility(primaryId, secondaryId, visible) {
-    const primary = document.getElementById(primaryId);
-    const secondary = secondaryId ? document.getElementById(secondaryId) : null;
-    if (primary) primary.classList.toggle('hidden', !visible);
-    if (secondary) secondary.classList.toggle('hidden', !visible);
+    const ids = secondaryId ? [primaryId, secondaryId] : [primaryId];
+    for (const id of ids) {
+      const el = document.getElementById(id);
+      if (!el) continue;
+      el.classList.toggle('hidden', !visible);
+      el.classList.toggle('ng2-btn-hidden', !visible);
+    }
   }
 
   // Generic element visibility control for toolbar/sidebar groups

--- a/lib/tests/component-logic.spec.ts
+++ b/lib/tests/component-logic.spec.ts
@@ -267,6 +267,38 @@ describe("wrapper event names map to component outputs", () => {
   });
 });
 
+describe("toolbar button hide survives PDF.js (#373)", () => {
+  // PDF.js re-asserts its own `hidden` class on the print button on every
+  // document load (its `printingallowed` handler), which wiped a plain
+  // `hidden`-only hide - the print icon reappeared, notably with the fast
+  // local load of a Blob source. The wrapper must hide buttons with the
+  // dedicated `ng2-btn-hidden` class (PDF.js never touches it) so the
+  // consumer's [controlVisibility] choice sticks. This pins that.
+  it("toggleButtonVisibility uses ng2-btn-hidden, not only PDF.js 'hidden'", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+    const src = readFileSync(
+      resolve(process.cwd(), "pdfjs/web/postmessage-wrapper.js"),
+      "utf8",
+    );
+    const fn = src.slice(
+      src.indexOf("function toggleButtonVisibility"),
+      src.indexOf("function toggleElementVisibilityById"),
+    );
+    expect(fn).toContain("ng2-btn-hidden");
+  });
+
+  it("ng2-customization.css defines ng2-btn-hidden as display:none !important", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+    const css = readFileSync(
+      resolve(process.cwd(), "pdfjs/web/ng2-customization.css"),
+      "utf8",
+    ).replace(/\s+/g, " ");
+    expect(css).toMatch(/\.ng2-btn-hidden\s*\{[^}]*display:\s*none\s*!important/);
+  });
+});
+
 describe("sidebar/layers/named-action/document-properties relays", () => {
   it("routes the four new event notifications to their @Output emitters", () => {
     const comp = makeComponent();


### PR DESCRIPTION
Fixes #373.

**Symptom:** `[controlVisibility]="{ print: false }"` (and `[showPrint]="false"`) failed to hide the print button when `pdfSrc` was a Blob — the printer icon stayed visible. Reported on 26.3.0 by @leominaudo and confirmed by others.

**Root cause:** PDF.js owns and re-asserts its own `hidden` class on the print button on every document load, via its `printingallowed` handler (`togglePrintingButtons(isAllowed)`). Our wrapper hid buttons by toggling that *same* `hidden` class, so when the document finished loading PDF.js removed it and the button reappeared. A Blob source loads instantly from local memory, so the re-show lands after our level-3 hide every time (a slow URL fetch can mask it). Verified live: after a Blob load the print button had **no** PDF.js `hidden` class yet was still expected hidden.

**Fix:** `toggleButtonVisibility` now also toggles a dedicated `ng2-btn-hidden` class (`display:none !important` in `ng2-customization.css`) that PDF.js never touches, alongside the existing `hidden` toggle (kept so buttons PDF.js hides by default, e.g. openFile, still reveal on show). A hide now survives PDF.js re-asserting `hidden`; a show clears our class and lets PDF.js govern.

**Verification (Playwright, local build against the patched lib):**
- Repro (Blob + `controlVisibility {print:false}`): print + secondaryPrint are `display:none` via `ng2-btn-hidden` after the document loads, even though PDF.js stripped its own `hidden` class.
- All six controls (print/download/find/fullscreen/bookmark) hide **and** show correctly round-trip.
- Smoke swept all 20 playground pages: viewer renders + document loads, 0 console/page errors.

Adds two guard tests pinning the wrapper class + CSS rule. Patch release 26.3.1.