### PR TITLE
Demo: bump playground to ng2-pdfjs-viewer 26.3.1

### DIFF
--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -15,7 +15,7 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/router": "^22.0.0",
         "@stackblitz/sdk": "^1.11.0",
-        "ng2-pdfjs-viewer": "^26.3.0",
+        "ng2-pdfjs-viewer": "^26.3.1",
         "rxjs": "^7.8.1",
         "tslib": "^2.6.0",
         "zone.js": "~0.15.0"
@@ -13271,9 +13271,9 @@
       }
     },
     "node_modules/ng2-pdfjs-viewer": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/ng2-pdfjs-viewer/-/ng2-pdfjs-viewer-26.3.0.tgz",
-      "integrity": "sha512-FfMwoa5tguhjQPnLFEWY8RoAsGaChscfbc3zKgWewTkgGCY8N9mlP7AFWKPEc4stKc9WGGV9grLyVMR7gGMoWg==",
+      "version": "26.3.1",
+      "resolved": "https://registry.npmjs.org/ng2-pdfjs-viewer/-/ng2-pdfjs-viewer-26.3.1.tgz",
+      "integrity": "sha512-L2ljDH+CNuxlpxhLcTehEoaVzYGY2JnNLT7cTY/v7Mbx4/+SNm7TPqcfw511VIMyglM9k7UNVStvgjmU6e8ANA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/playground/package.json
+++ b/playground/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser": "^22.0.0",
     "@angular/router": "^22.0.0",
     "@stackblitz/sdk": "^1.11.0",
-    "ng2-pdfjs-viewer": "^26.3.0",
+    "ng2-pdfjs-viewer": "^26.3.1",
     "rxjs": "^7.8.1",
     "tslib": "^2.6.0",
     "zone.js": "~0.15.0"


### PR DESCRIPTION
Bumps the playground's `ng2-pdfjs-viewer` pin to 26.3.1 so the deployed demo runs the build with the #373 print-visibility fix. Surgical lockfile edit (the lib entry + root dep only); package.json pin `^26.3.1`.