### PR TITLE
fix(compatibility): polyfill iframe loaded code to support more browsers

### DIFF
--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@angular/compiler-cli": "^22.0.0",
+        "core-js": "~3.49.0",
         "esbuild": "^0.28.0",
         "jsdom": "^29.1.1",
         "ng-packagr": "^22.0.0",
@@ -3077,6 +3078,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/css-tree": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -17,6 +17,7 @@
   "typings": "dist/types/ng2-pdfjs-viewer.d.ts",
   "devDependencies": {
     "@angular/compiler-cli": "^22.0.0",
+    "core-js": "^3.49.0",
     "esbuild": "^0.28.0",
     "jsdom": "^29.1.1",
     "ng-packagr": "^22.0.0",
@@ -68,9 +69,10 @@
   "readme": "README.md",
   "scripts": {
     "clean": "shx rm -rf ./dist",
-    "build": "npm run clean && ng-packagr -p ng-package.json && npm run copy-readme && npm run remove-source-maps && npm run minify-pdfjs && npm run minify-css",
+    "build": "npm run clean && ng-packagr -p ng-package.json && npm run copy-readme && npm run remove-source-maps && npm run polyfill-pdfjs && npm run minify-pdfjs && npm run minify-css",
     "copy-readme": "shx cp ../README.md dist/README.md",
     "remove-source-maps": "shx rm -f dist/pdfjs/build/*.map dist/pdfjs/web/*.map dist/fesm2022/*.map && node -e \"const fs=require('fs'),p='dist/fesm2022/ng2-pdfjs-viewer.mjs';fs.writeFileSync(p,fs.readFileSync(p,'utf8').replace(/\\/\\/# sourceMappingURL=\\S+\\s*$/,''))\"",
+    "polyfill-pdfjs": "esbuild pdfjs/build/pdf.mjs --bundle --minify --inject:src/polyfill.js --format=esm --target=es2022 --out-extension:.js=.mjs --outdir=dist/pdfjs/build && esbuild pdfjs/build/pdf.worker.mjs --bundle --minify --inject:src/polyfill.js --format=esm --target=es2022 --out-extension:.js=.mjs --outdir=dist/pdfjs/build",
     "minify-pdfjs": "terser dist/pdfjs/build/pdf.mjs --compress --mangle --module --output dist/pdfjs/build/pdf.mjs && terser dist/pdfjs/build/pdf.sandbox.mjs --compress --mangle --module --output dist/pdfjs/build/pdf.sandbox.mjs && terser dist/pdfjs/build/pdf.worker.mjs --compress --mangle --module --output dist/pdfjs/build/pdf.worker.mjs && terser dist/pdfjs/web/viewer.mjs --compress --mangle --module --output dist/pdfjs/web/viewer.mjs && terser dist/pdfjs/web/postmessage-wrapper.js --compress --mangle --output dist/pdfjs/web/postmessage-wrapper.js",
     "minify-css": "esbuild dist/pdfjs/web/viewer.css --minify --outfile=dist/pdfjs/web/viewer.css --allow-overwrite",
     "package": "npm run build && cd dist && npm pack",

--- a/lib/src/polyfill.js
+++ b/lib/src/polyfill.js
@@ -1,0 +1,5 @@
+import 'core-js/modules/es.map.get-or-insert-computed';
+import 'core-js/modules/es.promise.try';
+import 'core-js/modules/es.promise.with-resolvers';
+import 'core-js/modules/es.uint8-array.to-hex';
+import 'core-js/modules/web.url.parse';


### PR DESCRIPTION
Cause of iframe & worker solution we cannot provide wide browser compatibility.

This MR inject some polyfill code into pdf.mjs (first JS in viewer.html) and pdf.worker.mjs

Cause of PDF.js of Mozilla does not polyfill some API in base repository of modern build.

Current state is minimum Chrome 140 cause of Uint8Array.toHex used

Polyfill adds about 20К to minified versions but provide compatibility at least for Chrome 121 (as I tested)

Minimum worked version of Chrome is 125 because of CSS round() using for scale that I cannot polyfill )

Polifills included for:
- [Map.prototype.getOrInsertComputed](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/getOrInsertComputed)
- [Promise.try](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/try)
- [Promise.withResolvers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers)
- [Uint8Array.prototype.toHex](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/toHex)
- [URL.parse](https://developer.mozilla.org/en-US/docs/Web/API/URL/parse_static)