### PR TITLE
Release 26.4.0: bundle core-js polyfills for older-browser support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [26.4.0] - 2026-07-10
+
+### Added
+- The bundled PDF.js (`pdf.mjs` and `pdf.worker.mjs`) now ships with `core-js`
+  polyfills for five newer JavaScript APIs the PDF.js 6 build relies on —
+  `Map.prototype.getOrInsertComputed`, `Promise.try`, `Promise.withResolvers`,
+  `Uint8Array.prototype.toHex`, and `URL.parse`. Without them the viewer threw on
+  startup in browsers that predate those APIs; it now runs on those older engines.
+  The polyfills are injected into the two bundles at build time with esbuild, so
+  consumers pull in nothing new at runtime — `core-js` stays a build-only
+  dependency. Thanks to @delagen for the contribution. (#379)
+
 ## [26.3.1] - 2026-06-29
 
 ### Fixed

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ng2-pdfjs-viewer",
-  "version": "26.3.1",
+  "version": "26.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ng2-pdfjs-viewer",
-      "version": "26.3.1",
+      "version": "26.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@angular/compiler-cli": "^22.0.0",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-pdfjs-viewer",
-  "version": "26.3.1",
+  "version": "26.4.0",
   "description": "The most comprehensive Angular PDF viewer, powered by Mozilla PDF.js 6 — view, annotate, sign, fill forms, search, and read aloud from one component. 8.3M+ downloads, mobile-first, production-ready.",
   "author": {
     "name": "Aneesh Goapalakrishnan",


### PR DESCRIPTION
Cuts 26.4.0. Bumps the version and adds the CHANGELOG entry for the browser-compatibility work merged in #379: the bundled `pdf.mjs` and `pdf.worker.mjs` now carry core-js polyfills for the five newer JavaScript APIs the PDF.js 6 build calls (`Map.prototype.getOrInsertComputed`, `Promise.try`, `Promise.withResolvers`, `Uint8Array.prototype.toHex`, `URL.parse`), so the viewer runs on browsers that predate those APIs. The polyfills are injected at build time via esbuild; core-js stays a build-only dependency.

No source changes here beyond the version bump and CHANGELOG — the feature landed in #379. Tagging `v26.4.0` after merge triggers the OIDC npm publish (release-gated) and the GitHub release.