### PR TITLE
Demo: bump playground to ng2-pdfjs-viewer 26.4.0

### DIFF
--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -15,7 +15,7 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/router": "^22.0.0",
         "@stackblitz/sdk": "^1.11.0",
-        "ng2-pdfjs-viewer": "^26.3.1",
+        "ng2-pdfjs-viewer": "^26.4.0",
         "rxjs": "^7.8.1",
         "tslib": "^2.6.0",
         "zone.js": "~0.15.0"
@@ -13271,9 +13271,9 @@
       }
     },
     "node_modules/ng2-pdfjs-viewer": {
-      "version": "26.3.1",
-      "resolved": "https://registry.npmjs.org/ng2-pdfjs-viewer/-/ng2-pdfjs-viewer-26.3.1.tgz",
-      "integrity": "sha512-L2ljDH+CNuxlpxhLcTehEoaVzYGY2JnNLT7cTY/v7Mbx4/+SNm7TPqcfw511VIMyglM9k7UNVStvgjmU6e8ANA==",
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/ng2-pdfjs-viewer/-/ng2-pdfjs-viewer-26.4.0.tgz",
+      "integrity": "sha512-6nv7QmU2yeK5/Vr2tu6BJHJ+G2yOzhNhtZng2WQp7P50Rou9icgAumRRThjzgnDGptdyCtaiOSL91O/W0FcorQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/playground/package.json
+++ b/playground/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser": "^22.0.0",
     "@angular/router": "^22.0.0",
     "@stackblitz/sdk": "^1.11.0",
-    "ng2-pdfjs-viewer": "^26.3.1",
+    "ng2-pdfjs-viewer": "^26.4.0",
     "rxjs": "^7.8.1",
     "tslib": "^2.6.0",
     "zone.js": "~0.15.0"


### PR DESCRIPTION
Points the deployed playground/demo at the just-published 26.4.0 (older-browser polyfills, #379). Version + lockfile edited surgically (dep spec, version, resolved, integrity) so Vercel's `npm ci` resolves the new release.