### PR TITLE
26.4.1: citation metadata + author surname correction

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,41 @@
+{
+  "title": "ng2-pdfjs-viewer: an Angular component library for embedding and controlling Mozilla PDF.js",
+  "description": "<p>An Angular component library that wraps Mozilla PDF.js in a single <code>&lt;ng2-pdfjs-viewer&gt;</code> element, exposing viewing, printing, annotation, zoom, search, theming and accessibility through a declarative input and event surface. It ships a modified PDF.js viewer with its own event protocol, a headless signals store, and a bring-your-own-model AI entry point that requires no backend service.</p><p>Published on npm as <code>ng2-pdfjs-viewer</code>. Documentation at https://angularpdf.com.</p>",
+  "upload_type": "software",
+  "license": "Apache-2.0",
+  "access_right": "open",
+  "creators": [
+    {
+      "name": "Gopalakrishnan, Aneesh"
+    }
+  ],
+  "keywords": [
+    "angular",
+    "pdf",
+    "pdf viewer",
+    "pdfjs",
+    "typescript",
+    "web components",
+    "document viewer",
+    "annotations",
+    "accessibility",
+    "open source"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://www.npmjs.com/package/ng2-pdfjs-viewer",
+      "relation": "isIdenticalTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://angularpdf.com",
+      "relation": "isDocumentedBy",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/mozilla/pdf.js",
+      "relation": "isDerivedFrom",
+      "scheme": "url"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [26.4.1] - 2026-07-14
+
+### Added
+- `CITATION.cff` and `.zenodo.json`, so the library can be cited formally and each
+  release is archived with a DOI. GitHub renders a "Cite this repository" button
+  from the former; Zenodo reads the latter when it archives a release.
+
+### Fixed
+- The author's surname was misspelled ("Goapalakrishnan") in the package metadata
+  and in both `LICENSE` files. Because build tools copy that string into the
+  attribution files they generate, the typo had propagated into the open-source
+  notices published by downstream products. Corrected to "Gopalakrishnan".
+
 ## [26.4.0] - 2026-07-10
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,36 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: software
+title: "ng2-pdfjs-viewer"
+abstract: >-
+  An Angular component library that embeds Mozilla PDF.js as a fully
+  configurable viewer: declarative inputs and events for viewing, printing,
+  annotation, zoom, search, theming, and a headless BYO-AI entry point.
+authors:
+  - family-names: Gopalakrishnan
+    given-names: Aneesh
+    email: codehippie1@gmail.com
+    alias: intbot
+repository-code: "https://github.com/intbot/ng2-pdfjs-viewer"
+url: "https://angularpdf.com"
+license: Apache-2.0
+version: 26.4.0
+date-released: "2026-07-10"
+keywords:
+  - angular
+  - pdf
+  - pdf-viewer
+  - pdfjs
+  - pdf.js
+  - typescript
+  - annotations
+  - accessibility
+  - open-source
+references:
+  - type: software
+    title: "PDF.js"
+    abstract: "The PDF rendering engine this library embeds and extends."
+    authors:
+      - name: "Mozilla Foundation"
+    repository-code: "https://github.com/mozilla/pdf.js"
+    license: Apache-2.0

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018-2026 Aneesh Goapalakrishnan
+   Copyright 2018-2026 Aneesh Gopalakrishnan
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/lib/LICENSE
+++ b/lib/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018-2026 Aneesh Goapalakrishnan
+   Copyright 2018-2026 Aneesh Gopalakrishnan
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,9 +1,9 @@
 {
   "name": "ng2-pdfjs-viewer",
-  "version": "26.4.0",
+  "version": "26.4.1",
   "description": "The most comprehensive Angular PDF viewer, powered by Mozilla PDF.js 6 — view, annotate, sign, fill forms, search, and read aloud from one component. 8.3M+ downloads, mobile-first, production-ready.",
   "author": {
-    "name": "Aneesh Goapalakrishnan",
+    "name": "Aneesh Gopalakrishnan",
     "email": "codehippie1@gmail.com"
   },
   "repository": {


### PR DESCRIPTION
Metadata-only release. No library code changes.

**Added**
- `CITATION.cff` — GitHub renders a "Cite this repository" button from it.
- `.zenodo.json` — Zenodo reads this when archiving a release, so each release
  gets a DOI and the library becomes formally citable.

**Fixed**
- The author's surname was misspelled ("Goapalakrishnan") in `lib/package.json`
  and in both `LICENSE` files. Build tools copy that string into the attribution
  files they generate, so the typo had propagated into the open-source notices
  published by downstream products. Corrected to "Gopalakrishnan".

No runtime dependencies added; no files under `lib/src/` touched.