### PR TITLE
26.4.2: register the project with Zenodo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [26.4.2] - 2026-07-14
+
+### Added
+- The project is now registered with Zenodo, which archives each GitHub release
+  and mints a DOI for it. This release is the first one archived; `CITATION.cff`
+  is updated to match. No library changes.
+
 ## [26.4.1] - 2026-07-14
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,8 +14,8 @@ authors:
 repository-code: "https://github.com/intbot/ng2-pdfjs-viewer"
 url: "https://angularpdf.com"
 license: Apache-2.0
-version: 26.4.0
-date-released: "2026-07-10"
+version: 26.4.2
+date-released: "2026-07-14"
 keywords:
   - angular
   - pdf

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-pdfjs-viewer",
-  "version": "26.4.1",
+  "version": "26.4.2",
   "description": "The most comprehensive Angular PDF viewer, powered by Mozilla PDF.js 6 — view, annotate, sign, fill forms, search, and read aloud from one component. 8.3M+ downloads, mobile-first, production-ready.",
   "author": {
     "name": "Aneesh Gopalakrishnan",


### PR DESCRIPTION
Metadata-only release. No library code changes.

Zenodo now archives each GitHub release of this repository and mints a DOI for
it, so the library can be cited formally. This release is the first one archived;
`CITATION.cff` is updated to match.