### PR TITLE
Add Zenodo DOI badge; correct release dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [26.4.2] - 2026-07-14
+## [26.4.2] - 2026-07-25
 
 ### Added
 - The project is now registered with Zenodo, which archives each GitHub release
   and mints a DOI for it. This release is the first one archived; `CITATION.cff`
   is updated to match. No library changes.
 
-## [26.4.1] - 2026-07-14
+## [26.4.1] - 2026-07-25
 
 ### Added
 - `CITATION.cff` and `.zenodo.json`, so the library can be cited formally and each

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,8 +14,9 @@ authors:
 repository-code: "https://github.com/intbot/ng2-pdfjs-viewer"
 url: "https://angularpdf.com"
 license: Apache-2.0
+doi: 10.5281/zenodo.21584053
 version: 26.4.2
-date-released: "2026-07-14"
+date-released: "2026-07-25"
 keywords:
   - angular
   - pdf
@@ -34,3 +35,4 @@ references:
       - name: "Mozilla Foundation"
     repository-code: "https://github.com/mozilla/pdf.js"
     license: Apache-2.0
+doi: 10.5281/zenodo.21584053

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 [![Angular](https://img.shields.io/badge/Angular-%3E%3D10-red?style=flat-square&logo=angular)](https://angular.dev)
 [![PDF.js](https://img.shields.io/badge/PDF.js-6.0.227-green?style=flat-square&logo=mozilla)](https://github.com/mozilla/pdf.js)
 [![license](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square)](https://github.com/intbot/ng2-pdfjs-viewer/blob/master/LICENSE)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21584053.svg)](https://doi.org/10.5281/zenodo.21584053)
 [![stars](https://img.shields.io/github/stars/intbot/ng2-pdfjs-viewer?style=flat-square&logo=github)](https://github.com/intbot/ng2-pdfjs-viewer)
 [![Open in StackBlitz](https://img.shields.io/badge/Open%20in-StackBlitz-1389FD?style=flat-square&logo=stackblitz&logoColor=white)](https://stackblitz.com/github/intbot/ng2-pdfjs-viewer/tree/master/examples/quickstart)
 [![Edit on CodeSandbox](https://img.shields.io/badge/Edit%20on-CodeSandbox-151515?style=flat-square&logo=codesandbox&logoColor=white)](https://codesandbox.io/p/sandbox/github/intbot/ng2-pdfjs-viewer/tree/master/examples/quickstart)


### PR DESCRIPTION
- Adds the Zenodo DOI badge to the README, using the concept DOI
  (`10.5281/zenodo.21584053`) so it always resolves to the latest archived version.
- Records the same DOI in `CITATION.cff`.
- Corrects the dates on the 26.4.1 and 26.4.2 CHANGELOG entries and the
  `date-released` field: both releases were cut on 2026-07-25, not 2026-07-14.

Docs and metadata only.