### PR TITLE
fix(citation): remove duplicate doi key

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -35,4 +35,3 @@ references:
       - name: "Mozilla Foundation"
     repository-code: "https://github.com/mozilla/pdf.js"
     license: Apache-2.0
-doi: 10.5281/zenodo.21584053


### PR DESCRIPTION
The DOI line was accidentally appended twice — once in the record and once after the `references` block, leaving a duplicate key at root level. Removes the stray line; the file now has a single `doi` field.